### PR TITLE
Add Time12 v1.2.3 delay plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,12 @@ Then proceed to the Validate Changes, Commit Changes, Push Changes, and Submit P
 ## Contributing a package
 
 Prompt the user for a GitHub project url. For example they might respond with: `https://github.com/wolf-plugins/wolf-shaper`
-Then rpompt the user for the url to the specific GitHub release: https://github.com/wolf-plugins/wolf-shaper/releases/tag/v1.0.2
+Then prompt the user for the url to the specific GitHub release: https://github.com/wolf-plugins/wolf-shaper/releases/tag/v1.0.2
+You can get GitHub release filesizes and SHA256 hashes via curl such as:
+
+```bash
+curl -s https://api.github.com/repos/wolf-plugins/wolf-shaper/releases/tags/v1.0.2
+```
 
 Use these urls to automatically populate the package yaml metadata in the following steps.
 
@@ -51,7 +56,7 @@ Add new folders for your organization and package using [kebab-case](https://dev
 
     ./src/plugins/org-name/package-name
 
-Add a jpeg screenshot of the package, and flac audio file previewing the package:
+Add a jpeg screenshot of the package, and flac audio file previewing the package (Use the existing files if they already exist):
 
     ./src/plugins/org-name/package-name/package-name.flac
     ./src/plugins/org-name/package-name/package-name.jpg
@@ -126,10 +131,7 @@ Then proceed to the Validate Changes, Commit Changes, Push Changes, and Submit P
 Run formatting, linting, tests and build commands to validate your changes:
 
 ```bash
-npm run format
-npm run lint
-npm test
-npm run build
+npm run check
 ```
 
 Verify that all tests pass and there are no linting errors.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "check": "npm run format && npm run lint && npm run build",
+    "check": "npm run format && npm run lint && npm run build && npm test",
     "copy": "cp -rf ./src/apps ./out && cp -rf ./src/plugins ./out && cp -rf ./src/presets ./out && cp -rf ./src/projects ./out",
     "dev": "tsx ./src/index.ts",
     "dev:reorder": "tsx ./src/reorder.ts",

--- a/src/plugins/tiagolr/time12/1.2.3/index.yaml
+++ b/src/plugins/tiagolr/time12/1.2.3/index.yaml
@@ -1,0 +1,50 @@
+name: TIME-12
+author: TiagoLr
+description: Delay modulator similar to plugins like GrossBeat or TimeShaper. Can be used for stutter effects, tape stop, glitch, scratch, reverse, pitch shift and more.
+license: gpl-3.0
+type: effect
+tags:
+  - Effect
+  - Modulation
+  - Delay
+url: https://github.com/tiagolr/time12
+audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/tiagolr/time12/time12.flac
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/tiagolr/time12/time12.jpg
+date: '2026-11-01T00:00:00.000Z'
+changes: |
+  - Ignore sub-millisecond playhead movements
+files:
+  - architectures:
+      - x64
+    contains:
+      - lv2
+      - vst3
+    sha256: d1e19e0c2e5332626af3077d4dd98dcaeb4b4c2b33ee74c267a732c29df10613
+    systems:
+      - type: linux
+    size: 5066023
+    type: archive
+    url: https://github.com/tiagolr/time12/releases/download/v1.2.3/time12-linux-v1.2.3.zip
+  - architectures:
+      - x64
+    contains:
+      - component
+      - lv2
+      - vst3
+    sha256: 9066d0f46fe0cbce102296180d157a176708654b9d6488f6d616e9e3d5cf45e4
+    systems:
+      - type: mac
+    size: 12313409
+    type: archive
+    url: https://github.com/tiagolr/time12/releases/download/v1.2.3/time12-macos-v1.2.3.zip
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - lv2
+      - vst3
+    type: archive
+    size: 5539406
+    sha256: b5699e49850826a8279e315d51cc8cf92636fc98d5d649bcfadd7ae026982989
+    url: https://github.com/tiagolr/time12/releases/download/v1.2.3/time12-win-v1.2.3.zip


### PR DESCRIPTION
Adds Time12 v1.2.3, a delay plugin with 12 independent taps by tiagolr. Includes Windows x64, macOS (ARM64/x64), and Linux x64 VST3 builds with verified file sizes and SHA256 hashes from GitHub release.

Fixes #193