### PR TITLE
Update contributing guidelines for GitHub packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,10 @@ Then proceed to the Validate Changes, Commit Changes, Push Changes, and Submit P
 
 ## Contributing a package
 
-Prompt the user for a GitHub project url. For example they might respond with: `https://github.com/wolf-plugins/wolf-shaper` or a url to the specific GitHub release: https://github.com/wolf-plugins/wolf-shaper/releases/tag/v1.0.2 if they don't specify a release get the latest release that corresponds to the date they provided, if they did not provide a specific release or a specific date, then use the most latest release. If the user responds with a url to a site that isn't Github, such as Codeberg or Gitlab, then only fill in the metadata you are able to webscrape.
+Prompt the user for a GitHub project url. For example they might respond with: `https://github.com/wolf-plugins/wolf-shaper` or a url to the specific GitHub release: https://github.com/wolf-plugins/wolf-shaper/releases/tag/v1.0.2
+- If the user does not specify a release, get the latest release that corresponds to the date they provided.
+- If the user did not provide a specific release or a specific date, then use the most latest release.
+- If the user responds with a url to a site that isn't Github, such as Codeberg or Gitlab, then only fill in the metadata you are able to webscrape.
 
 You can get GitHub repo metadata and release filesizes and SHA256 hashes via curl such as:
 


### PR DESCRIPTION
Clarify instructions for handling GitHub project URLs and metadata retrieval.