### PR TITLE
fix: return non-zero exit code from validate script on errors

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,11 +35,13 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
+          exit_code=0
           for file in ${CHANGED_FILES}; do
-            node ./build/validate.js $file
+            node ./build/validate.js $file || exit_code=$?
           done
           echo 'Downloads:'
           ls ./test/downloads/ || true
+          exit $exit_code
 
       - name: VirusTotal Scan
         id: virustotal

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -29,6 +29,8 @@ pkg.addVersion(version, pkgJson);
 pkg.logEnable();
 pkg.outputReport();
 
+let hasErrors = false;
+
 // Loop through files in yaml file
 for (const type in pkgJson.files) {
   const file: PluginFile | PresetFile | ProjectFile = pkgJson.files[type];
@@ -46,12 +48,14 @@ for (const type in pkgJson.files) {
 
   // Validate file vs package metadata and output errors
   const errorsFile = await fileValidateMetadata(fileLocalPath, file);
+  if (errorsFile.length > 0) hasErrors = true;
   pkg.logErrors(errorsFile);
 }
 
 // Ensure image and audio files exist locally in registry
 const audioPathLocal = pkgJson.audio?.replace('https://open-audio-stack.github.io/open-audio-stack-registry/', 'src/');
 if (audioPathLocal && !fileExists(audioPathLocal)) {
+  hasErrors = true;
   pkg.logErrors([
     {
       message: 'File does not exist locally',
@@ -64,6 +68,7 @@ const imagePathLocal: string = pkgJson.image.replace(
   'src/',
 );
 if (!fileExists(imagePathLocal)) {
+  hasErrors = true;
   pkg.logErrors([
     {
       message: 'File does not exist locally',
@@ -71,3 +76,5 @@ if (!fileExists(imagePathLocal)) {
     },
   ] as ZodIssue[]);
 }
+
+if (hasErrors) process.exit(1);


### PR DESCRIPTION
## Summary
- `src/validate.ts`: tracks `hasErrors` flag across file validation and image/audio existence checks; calls `process.exit(1)` at the end if any errors were found
- `.github/workflows/validate.yml`: CI loop now accumulates exit codes across all changed files rather than discarding them, so a failing file fails the whole step
- Informational warnings (arm64 support, .pkg recommendation) still log but do **not** trigger a failure

## Behaviour
| Condition | Before | After |
|---|---|---|
| Missing image/audio file | exit 0 | exit 1 |
| SHA256 / size mismatch | exit 0 | exit 1 |
| "architectures should support arm64" | exit 0 | exit 0 |
| "url requires mounting step" | exit 0 | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)