### PR TITLE
fix: enforce Title Case on all registry tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ The script is deterministic — it reads only what GitHub's API and the README p
 
 **`type`** — inferred by scoring keywords in the description, topics, and README. This can misfire, especially for plugins that are clearly effects (tape, distortion, EQ) but whose README doesn't use the expected keywords. Always confirm: `instrument` / `effect` / `sampler` / `generator` / `tool`.
 
-**`tags`** — sourced from GitHub repository topics and converted to Title Case. GitHub topics are technical (e.g. `vst3-plugin`, `juce`) while registry tags should be semantic categories (e.g. `Effect`, `Filter`, `Tape`). Replace with meaningful registry tags.
+**`tags`** — **All tags MUST be Title Case** (e.g. `Guitar`, `Pitch Shifter`, `Noise Gate`). The fetch script converts GitHub topics automatically; if you add or edit tags manually, apply Title Case. GitHub topics are technical (e.g. `vst3-plugin`, `juce`) while registry tags should be semantic categories (e.g. `Effect`, `Filter`, `Tape`). Replace with meaningful registry tags. Run `npm run dev:fix-tags` to bulk-fix any all-lowercase tags across the registry.
 
 **`changes`** — taken verbatim from the GitHub release body, trimmed to 255 characters. Release bodies often include headers, markdown formatting, or unrelated links. Clean up to a concise bullet list of changes.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:reorder": "tsx ./src/reorder.ts",
     "dev:upgrade": "tsx ./src/upgrade.ts",
     "dev:fetch": "tsx ./src/fetch.ts",
+    "dev:fix-tags": "tsx ./src/fix-tags.ts",
     "dev:validate": "tsx ./src/validate.ts",
     "dev:validate:all": "for file in $(find src -type f -name '*.yaml'); do node ./build/validate.js $file; done",
     "format": "prettier . --write",

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -385,7 +385,11 @@ async function main() {
   console.log('\n─── Fields requiring review ───');
   console.log(`  name:    "${pkg.name}"  — confirm display name matches plugin branding`);
   console.log(`  type:    "${pkg.type}"  — confirm: instrument / effect / sampler / generator / tool`);
-  console.log(`  tags:    ${JSON.stringify(pkg.tags)}  — sourced from GitHub topics, adjust as needed`);
+  const nonTitleCaseTags = (pkg.tags as string[]).filter(t => t !== slugToTitleCase(t));
+  const tagsNote = nonTitleCaseTags.length
+    ? `  ⚠ not Title Case: ${nonTitleCaseTags.join(', ')}`
+    : '  — sourced from GitHub topics, adjust as needed';
+  console.log(`  tags:    ${JSON.stringify(pkg.tags)}${tagsNote}`);
   console.log(`  changes: verify formatting and accuracy`);
   if (!existsSync(audioLocalPath)) console.log(`  audio:   not found — add manually if a demo is available`);
   if (!existsSync(imageLocalPath)) console.log(`  image:   not found — add manually if available`);

--- a/src/fix-tags.ts
+++ b/src/fix-tags.ts
@@ -1,0 +1,63 @@
+// One-time script: converts all-lowercase tags to Title Case across the registry.
+// Only tags where every letter is lowercase are touched; tags with any uppercase
+// (acronyms, brands, already-correct) are left unchanged.
+// Usage: npm run dev:fix-tags
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+function slugToTitleCase(slug: string): string {
+  return slug
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[-_\s]+/)
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function fixTag(tag: string): string {
+  // Only fix tags that are entirely lowercase (no uppercase letters at all)
+  if (/[a-z]/.test(tag) && !/[A-Z]/.test(tag)) {
+    return slugToTitleCase(tag);
+  }
+  return tag;
+}
+
+function findYamlFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...findYamlFiles(full));
+    } else if (entry === 'index.yaml') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+let filesChanged = 0;
+let tagsFixed = 0;
+
+for (const filePath of findYamlFiles('src')) {
+  const original = readFileSync(filePath, 'utf8');
+
+  const updated = original.replace(
+    /(^tags:\n)((?:  - .+\n)*)/m,
+    (_, header, tagLines) => {
+      const fixedLines = tagLines.replace(/^(  - )(.+)$/gm, (_line, prefix, tag) => {
+        const fixed = fixTag(tag.trim());
+        if (fixed !== tag.trim()) tagsFixed++;
+        return `${prefix}${fixed}`;
+      });
+      return header + fixedLines;
+    },
+  );
+
+  if (updated !== original) {
+    writeFileSync(filePath, updated, 'utf8');
+    console.log(`Fixed: ${filePath}`);
+    filesChanged++;
+  }
+}
+
+console.log(`\n${tagsFixed} tag(s) updated across ${filesChanged} file(s).`);

--- a/src/fix-tags.ts
+++ b/src/fix-tags.ts
@@ -41,17 +41,14 @@ let tagsFixed = 0;
 for (const filePath of findYamlFiles('src')) {
   const original = readFileSync(filePath, 'utf8');
 
-  const updated = original.replace(
-    /(^tags:\n)((?:  - .+\n)*)/m,
-    (_, header, tagLines) => {
-      const fixedLines = tagLines.replace(/^(  - )(.+)$/gm, (_line, prefix, tag) => {
-        const fixed = fixTag(tag.trim());
-        if (fixed !== tag.trim()) tagsFixed++;
-        return `${prefix}${fixed}`;
-      });
-      return header + fixedLines;
-    },
-  );
+  const updated = original.replace(/(^tags:\n)((?: {2}- .+\n)*)/m, (_, header, tagLines) => {
+    const fixedLines = tagLines.replace(/^( {2}- )(.+)$/gm, (_line: string, prefix: string, tag: string) => {
+      const fixed = fixTag(tag.trim());
+      if (fixed !== tag.trim()) tagsFixed++;
+      return `${prefix}${fixed}`;
+    });
+    return header + fixedLines;
+  });
 
   if (updated !== original) {
     writeFileSync(filePath, updated, 'utf8');

--- a/src/plugins/endolith/salamander-drumkit/1.0.0/index.yaml
+++ b/src/plugins/endolith/salamander-drumkit/1.0.0/index.yaml
@@ -6,7 +6,7 @@ type: sampler
 tags:
   - Instrument
   - Drums
-  - sfz
+  - Sfz
 url: https://github.com/endolith/salamander-drumkit
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/endolith/salamander-drumkit/salamander-drumkit.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/endolith/salamander-drumkit/salamander-drumkit.jpg

--- a/src/plugins/freepats/glasses-of-water/1.0.0/index.yaml
+++ b/src/plugins/freepats/glasses-of-water/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Orchestra
   - Glass
-  - sfz
+  - Sfz
 url: https://github.com/freepats/glass
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/glasses-of-water/glasses-of-water.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/glasses-of-water/glasses-of-water.jpg

--- a/src/plugins/freepats/hang-d-minor/20220330.0.0/index.yaml
+++ b/src/plugins/freepats/hang-d-minor/20220330.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Orchestra
   - Hang
-  - sfz
+  - Sfz
 url: https://github.com/freepats/hang-d-minor
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/hang-d-minor/hang-d-minor.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/hang-d-minor/hang-d-minor.jpg

--- a/src/plugins/freepats/spanish-classical-guitar/1.0.0/index.yaml
+++ b/src/plugins/freepats/spanish-classical-guitar/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Guitar
   - Classical
-  - sfz
+  - Sfz
 url: https://github.com/freepats/spanish-classical-guitar
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/spanish-classical-guitar/spanish-classical-guitar.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/spanish-classical-guitar/spanish-classical-guitar.jpg

--- a/src/plugins/freepats/synthesizer-percussion/1.0.0/index.yaml
+++ b/src/plugins/freepats/synthesizer-percussion/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Drums
   - Electro
-  - sfz
+  - Sfz
 url: https://github.com/freepats/synthesizer-percussion
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/synthesizer-percussion/synthesizer-percussion.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/synthesizer-percussion/synthesizer-percussion.jpg

--- a/src/plugins/freepats/upright-piano-kw/1.0.0/index.yaml
+++ b/src/plugins/freepats/upright-piano-kw/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Keys
   - Piano
-  - sfz
+  - Sfz
 url: https://github.com/freepats/upright-piano-kw
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/upright-piano-kw/upright-piano-kw.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/freepats/upright-piano-kw/upright-piano-kw.jpg

--- a/src/plugins/iamlamprey/altar/0.4.0/index.yaml
+++ b/src/plugins/iamlamprey/altar/0.4.0/index.yaml
@@ -4,13 +4,13 @@ description: Modular DSP with guitar amplifier models, cab IRs, NAM (A1/A2) supp
 type: effect
 license: gpl-3.0
 tags:
-  - guitar
-  - amp
-  - amplifier
-  - cab
+  - Guitar
+  - Amp
+  - Amplifier
+  - Cab
   - NAM
-  - effect
-  - modular
+  - Effect
+  - Modular
 url: https://github.com/iamlamprey/altar
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/iamlamprey/altar/altar.jpg
 date: '2026-06-15T09:23:53Z'

--- a/src/plugins/masseyis/plaits-vst/1.1.0/index.yaml
+++ b/src/plugins/masseyis/plaits-vst/1.1.0/index.yaml
@@ -4,12 +4,12 @@ description: Polyphonic VST3/AU plugin port of Mutable Instruments Plaits macro-
 license: mit
 type: instrument
 tags:
-  - plaits
-  - mutable-instruments
-  - macro-oscillator
-  - synthesizer
-  - polyphonic
-  - eurorack
+  - Plaits
+  - Mutable Instruments
+  - Macro Oscillator
+  - Synthesizer
+  - Polyphonic
+  - Eurorack
 url: https://github.com/masseyis/plaits-vst
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/masseyis/plaits-vst/plaits-vst.jpg
 date: '2025-12-02T10:04:57Z'

--- a/src/plugins/michael02022/basic-harmonica/1.0.0/index.yaml
+++ b/src/plugins/michael02022/basic-harmonica/1.0.0/index.yaml
@@ -8,7 +8,7 @@ tags:
   - Wind
   - Harmonica
   - Orchestra
-  - sfz
+  - Sfz
 url: https://github.com/michael02022/basic-harmonica
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/michael02022/basic-harmonica/basic-harmonica.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/michael02022/basic-harmonica/basic-harmonica.jpg

--- a/src/plugins/open-soundfonts/virtual-playing-orchestra/3.3.2/index.yaml
+++ b/src/plugins/open-soundfonts/virtual-playing-orchestra/3.3.2/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Orchestral
   - Strings
-  - sfz
+  - Sfz
 url: https://github.com/open-soundfonts/Virtual_Playing_Orchestra_3
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/open-soundfonts/virtual-playing-orchestra/virtual-playing-orchestra.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/open-soundfonts/virtual-playing-orchestra/virtual-playing-orchestra.jpg

--- a/src/plugins/peastman/sonatina-symphonic-orchestra/4.0.0/index.yaml
+++ b/src/plugins/peastman/sonatina-symphonic-orchestra/4.0.0/index.yaml
@@ -11,7 +11,7 @@ tags:
   - Brass
   - Piano
   - Organ
-  - sfz
+  - Sfz
 url: https://github.com/peastman/sso
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/peastman/sonatina-symphonic-orchestra/sonatina-symphonic-orchestra.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/peastman/sonatina-symphonic-orchestra/sonatina-symphonic-orchestra.jpg

--- a/src/plugins/sfzinstruments/bear-sax/1004.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/bear-sax/1004.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Brass
   - Saxophone
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/karoryfer.bear-sax
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/bear-sax/bear-sax.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/bear-sax/bear-sax.jpg

--- a/src/plugins/sfzinstruments/black-and-green-guitars/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/black-and-green-guitars/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Guitar
   - Electric
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/karoryfer.black-and-green-guitars
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/black-and-green-guitars/black-and-green-guitars.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/black-and-green-guitars/black-and-green-guitars.jpg

--- a/src/plugins/sfzinstruments/double-bass/1.0.1/index.yaml
+++ b/src/plugins/sfzinstruments/double-bass/1.0.1/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - String
   - Bass
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/dsmolken.double-bass
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/double-bass/double-bass.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/double-bass/double-bass.jpg

--- a/src/plugins/sfzinstruments/horse-pulse/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/horse-pulse/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - String
   - Pluck
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/Karoryfer.HorsePulse
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/horse-pulse/horse-pulse.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/horse-pulse/horse-pulse.jpg

--- a/src/plugins/sfzinstruments/hungarian-zither/1.0.1/index.yaml
+++ b/src/plugins/sfzinstruments/hungarian-zither/1.0.1/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Strings
   - Classical
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/hungarian_zither
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/hungarian-zither/hungarian-zither.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/hungarian-zither/hungarian-zither.jpg

--- a/src/plugins/sfzinstruments/jrhodes3c/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/jrhodes3c/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Keys
   - Rhodes
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/jlearman.jRhodes3c
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/jrhodes3c/jrhodes3c.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/jrhodes3c/jrhodes3c.jpg

--- a/src/plugins/sfzinstruments/jsteeldrum/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/jsteeldrum/1.0.0/index.yaml
@@ -8,7 +8,7 @@ tags:
   - Steel
   - Drum
   - Orchestra
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/jlearman.SteelDrum
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/jsteeldrum/jsteeldrum.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/jsteeldrum/jsteeldrum.jpg

--- a/src/plugins/sfzinstruments/nakeddrums/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/nakeddrums/1.0.0/index.yaml
@@ -6,7 +6,7 @@ type: sampler
 tags:
   - Instrument
   - Drums
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/WilkinsonAudio.NakedDrums
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/nakeddrums/nakeddrums.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/nakeddrums/nakeddrums.jpg

--- a/src/plugins/sfzinstruments/salamandergrandpiano/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/salamandergrandpiano/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Piano
   - Yamaha
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/SalamanderGrandPiano
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/splendidgrandpiano/splendid-grand-piano.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/splendidgrandpiano/splendid-grand-piano.jpg

--- a/src/plugins/sfzinstruments/samssonor/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/samssonor/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Drums
   - Kit
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/SamsSonor
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/samssonor/samssonor.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/samssonor/samssonor.jpg

--- a/src/plugins/sfzinstruments/splendidgrandpiano/1.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/splendidgrandpiano/1.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Keys
   - Piano
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/splendidgrandpiano
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/splendidgrandpiano/splendid-grand-piano.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/splendidgrandpiano/splendid-grand-piano.jpg

--- a/src/plugins/sfzinstruments/virtuosity_drums/0.924.0/index.yaml
+++ b/src/plugins/sfzinstruments/virtuosity_drums/0.924.0/index.yaml
@@ -8,7 +8,7 @@ tags:
   - Instrument
   - Drums
   - Jazz
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/virtuosity_drums
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/virtuosity_drums/virtuosity-drums.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/virtuosity_drums/virtuosity-drums.jpg

--- a/src/plugins/sfzinstruments/virtuosity_drums/0.925.0/index.yaml
+++ b/src/plugins/sfzinstruments/virtuosity_drums/0.925.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Drums
   - Jazz
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/virtuosity_drums
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/virtuosity_drums/virtuosity-drums.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/virtuosity_drums/virtuosity-drums.jpg

--- a/src/plugins/sfzinstruments/war-tuba/1002.0.0/index.yaml
+++ b/src/plugins/sfzinstruments/war-tuba/1002.0.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Brass
   - Tuba
-  - sfz
+  - Sfz
 url: https://github.com/sfzinstruments/karoryfer.war-tuba
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/war-tuba/war-tuba.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/sfzinstruments/war-tuba/war-tuba.jpg

--- a/src/plugins/studiorack/avl-drumkits/1.1.0/index.yaml
+++ b/src/plugins/studiorack/avl-drumkits/1.1.0/index.yaml
@@ -6,7 +6,7 @@ type: sampler
 tags:
   - Instrument
   - Drums
-  - sfz
+  - Sfz
 url: https://github.com/studiorack/avl-drumkits
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/studiorack/avl-drumkits/avl-drumkits.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/studiorack/avl-drumkits/avl-drumkits.jpg

--- a/src/plugins/studiorack/avl-percussions/1.1.0/index.yaml
+++ b/src/plugins/studiorack/avl-percussions/1.1.0/index.yaml
@@ -7,7 +7,7 @@ tags:
   - Instrument
   - Drums
   - Percussions
-  - sfz
+  - Sfz
 url: https://github.com/studiorack/avl-percussions
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/studiorack/avl-percussions/avl-percussions.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/studiorack/avl-percussions/avl-percussions.jpg

--- a/src/plugins/yokemura/magical8bitplug2/1.0.1/index.yaml
+++ b/src/plugins/yokemura/magical8bitplug2/1.0.1/index.yaml
@@ -5,11 +5,11 @@ license: gpl-3.0
 type: instrument
 tags:
   - 8bit
-  - chiptune
-  - nes
-  - gameboy
-  - synthesizer
-  - retro
+  - Chiptune
+  - Nes
+  - Gameboy
+  - Synthesizer
+  - Retro
 url: https://github.com/yokemura/Magical8bitPlug2
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/yokemura/magical8bitplug2/magical8bitplug2.jpg
 date: '2021-05-08T09:33:26Z'

--- a/src/presets/antoinegehinstudios/gossip/1.0.0/index.yaml
+++ b/src/presets/antoinegehinstudios/gossip/1.0.0/index.yaml
@@ -5,10 +5,10 @@ license: gpl-3.0
 type: patch
 tags:
   - Surge
-  - scene
-  - cyberpunk
-  - android
-  - robots
+  - Scene
+  - Cyberpunk
+  - Android
+  - Robots
 url: https://github.com/antoinegehinstudios/surgeXT-preset
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/presets/antoinegehinstudios/gossip/gossip.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/presets/antoinegehinstudios/gossip/gossip.jpg

--- a/src/presets/antoinegehinstudios/kappa/1.0.0/index.yaml
+++ b/src/presets/antoinegehinstudios/kappa/1.0.0/index.yaml
@@ -5,11 +5,11 @@ license: gpl-3.0
 type: patch
 tags:
   - Surge
-  - scene
-  - animals
-  - water
-  - kappa
-  - yokai
+  - Scene
+  - Animals
+  - Water
+  - Kappa
+  - Yokai
 url: https://github.com/antoinegehinstudios/surgeXT-preset
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/presets/antoinegehinstudios/kappa/kappa.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/presets/antoinegehinstudios/kappa/kappa.jpg

--- a/src/presets/antoinegehinstudios/synthpunk/1.0.0/index.yaml
+++ b/src/presets/antoinegehinstudios/synthpunk/1.0.0/index.yaml
@@ -5,7 +5,7 @@ license: gpl-3.0
 type: patch
 tags:
   - Synth
-  - cyberpunk
+  - Cyberpunk
   - OneManSynth
   - Surge
 url: https://github.com/antoinegehinstudios/surgeXT-preset


### PR DESCRIPTION
## Summary
- **`src/fix-tags.ts`** — one-time bulk-fix script: converts all-lowercase tags to Title Case using the same `slugToTitleCase` logic as the fetch script; only touches tags with no uppercase letters at all, so acronyms (`NAM`, `EQ`, `SFZ`) and already-correct tags are left untouched
- **`src/fetch.ts`** — review output now prints a `⚠ not Title Case:` warning if any generated tag doesn't match Title Case, catching edge cases at generation time
- **`AGENTS.md`** — tags guidance updated from a note to an explicit **MUST** rule, with a pointer to `npm run dev:fix-tags`
- **`package.json`** — adds `dev:fix-tags` script entry
- **31 registry files updated** — 52 tags fixed (mostly `sfz` → `Sfz`, plus `guitar/amp/effect` → `Guitar/Amp/Effect`, `plaits/mutable-instruments/eurorack` → `Plaits/Mutable Instruments/Eurorack`, etc.)

## Stats
```
52 tag(s) updated across 31 file(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)