### PR TITLE
Fix win32/win64 filename detection regression from #349

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -70,8 +70,9 @@ function inferSystems(filename: string): Array<{ type: string }> {
   const f = filename.toLowerCase();
   const found = new Set<string>();
   // Left-boundary guard is required: plain substring matching on "win" false-positives
-  // inside product names like "airWINdows-..." and "clang-arm64-darWIN.dmg".
-  if (/(?<![a-z])win(?:dows)?(?=[-_.]|$)|\.exe$|\.msi$/.test(f)) found.add('win');
+  // inside product names like "airWINdows-..." and "clang-arm64-darWIN.dmg". The right
+  // side must allow a digit too ("win32", "win64" have no separator before the number).
+  if (/(?<![a-z])win(?:dows)?(?=[-_.0-9]|$)|\.exe$|\.msi$/.test(f)) found.add('win');
   if (/mac(os)?[-_.]|[-_.]mac(os)?|\bosx\b|darwin|\.dmg$|\.pkg$/.test(f)) found.add('mac');
   // Distro names (ubuntu, debian, fedora) are common in CI-built asset names and carry
   // no literal "linux" substring — without this, those assets are silently dropped below.


### PR DESCRIPTION
## Summary

Follow-up to #349. That fix required a separator (`-`, `_`, `.`) or end-of-string right after `win`/`windows` to avoid false-positives inside words like "airwindows" and "darwin". But it over-corrected: the extremely common `win32`/`win64` filename pattern has no separator between "win" and the digits, so those assets were silently dropped by the same "skipped asset" mechanism #349 added.

Caught while fetching brummer10/Ratatouille.lv2 — all 5 Windows release assets were skipped until this fix.

## Test plan
- [x] `npm run check` passes
- [x] Re-ran fetch against Ratatouille.lv2 — all 5 Windows assets now included, only the source tarball is skipped (correctly)
- [x] Re-verified `airwindows-consolidated-*.dmg` and `*-darwin.dmg` still correctly do NOT match `win` (no regression on the original #349 fix)