### PR TITLE
Auto-detect OS version constraints (systems[].min) in fetch script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,20 @@ The script is deterministic — it reads only what GitHub's API and the README p
 
 **`architectures`** — inferred from asset filenames (e.g. `x64`, `arm64`, `arm64ec`, `arm32`, `m1`). Filenames that give no architecture hint default to `[x64]`. Mac builds that are universal binaries (arm64 + x64) often have no hint in the filename — check the release notes or README to confirm, or download and run `lipo -info` on the binary. There is no registry value for RISC-V (`riscv64`) — the fetch script drops these assets automatically and flags them in its "skipped" list; leave them out rather than mislabeling the architecture.
 
+**`systems[].min` / `systems[].max`** — optional OS version bounds (see <a href="specification.md#file">the spec</a>). **The default is no constraint** — if a plugin author doesn't say otherwise, assume the build works on every version of that OS and leave `min`/`max` off entirely. Only add a bound when there's actual evidence: a filename token (`windows7`, `macos-10.15`), a release-notes line, a README requirement, or a CI config that targets a specific minimum.
+
+The fetch script auto-detects the common filename patterns:
+
+- Windows: a literal `win7`/`windows7`/`win10`/`win11`-style token → `min` set to that number. This is usually a _compatibility_ build offered _alongside_ a regular build, not a replacement — see below.
+- macOS: a deployment-target-looking number next to `mac`/`macos`/`osx` (e.g. `macos-10.15.dmg`, `mac-universal-11.dmg`) → `min` set to that number. Genuine macOS versions are always low two-digit numbers with an optional decimal (`10.13`, `11`, `14.2`) — the detector deliberately won't match a longer digit run, so a date-stamped filename like `macOS-2026-06-27-abc123.dmg` (common in CI-built nightlies) correctly produces no constraint instead of misreading "20" as the OS version.
+- Linux is **intentionally never auto-constrained**. A distro tag like `ubuntu-20.04` or `fedora-38` reflects the CI build environment's glibc floor, not a "Linux OS version" in the same sense — there's no single number that means the same thing to an end user the way `mac`/`win` versions do. If a Linux binary genuinely won't run on older distros, note this as a limitation but don't fabricate a `min`.
+
+What the script **cannot** infer, and you should add by hand after checking the repo:
+
+- The Windows _minimum_ for a **regular** (non-`win7`-tagged) build. When a project ships both a `win7`-suffixed compatibility build and a plain one, the plain build usually has an implicit floor (often Windows 10, because the current JUCE/toolchain dropped support for older Windows) even though nothing in its filename says so. Check the CI workflow (look for a flag like `downgrade_juce`/`ONJUCE7`/similar paired with the win7 variant) or ask upstream — don't leave the regular build unconstrained if you have good evidence it doesn't run on 7/8.
+- Any minimum stated only in prose ("Requires macOS 11 Big Sur or later", "Windows 10 1903+ required") — read the README/release notes for this, since the filename won't always carry it.
+- An upper bound (`max`). This is rare — only add one if you have positive evidence the build is broken or blocked on newer OS versions (e.g. an old 32-bit-only Windows build that Windows 11 dropped support for). Don't infer a `max` just because a `min` exists elsewhere; a compatibility build is usually a floor, not a ceiling — most old-OS builds keep working on newer systems too.
+
 **`contains`** — inferred from asset filenames first, then the release body, then the README. For installer packages (`.exe`, `.dmg`, `.deb`) this is especially unreliable because the installer bundles multiple formats internally, and single-archive builds (common for DPF/JUCE projects) often carry no format hint in the filename at all. When the fetch script flags a file's `contains` as unknown, or when a plugin ships one installer per platform bundling several formats, **do not guess** — download the asset and list its contents directly:
 
 ```bash

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -66,7 +66,31 @@ function versionNormalize(tag: string): string {
 
 // ── Filename inference helpers ────────────────────────────────────────────────
 
-function inferSystems(filename: string): Array<{ type: string }> {
+// Detects an OS version floor embedded in the filename — e.g. "win7"/"windows7" for a
+// build that specifically targets older Windows, or a macOS deployment target like
+// "macos-10.15"/"macos-universal-10.13". Returns {} (no constraint) when there's no
+// clear hint: per registry convention, omitting min means "supports all versions",
+// which must stay the default. Never guess a number — only a literal version token
+// adjacent to the OS name counts as evidence.
+function inferVersionConstraint(filename: string, systemType: string): { min?: number } {
+  const f = filename.toLowerCase();
+  if (systemType === 'win') {
+    const m = f.match(/(?<![a-z])win(?:dows)?[-_]?(7|8(?:\.1)?|10|11)(?![0-9])/);
+    if (m) return { min: parseFloat(m[1]) };
+  }
+  if (systemType === 'mac') {
+    // (?!\d) at the end stops a date like "macOS-2024-07-28" from matching "20" as
+    // if it were a truncated macOS version number.
+    const m = f.match(/(?:macos|osx|mac)(?:[-_](?:universal|intel|arm64))?[-_](\d{1,2}(?:\.\d{1,2})?)(?!\d)/);
+    if (m) return { min: parseFloat(m[1]) };
+  }
+  // Linux intentionally excluded: distro version tokens (ubuntu-20.04, fedora-38) reflect
+  // the build environment's glibc floor, not a single "Linux OS version" a user can reason
+  // about the same way — flagging this to a human is more honest than a fabricated number.
+  return {};
+}
+
+function inferSystems(filename: string): Array<{ type: string; min?: number }> {
   const f = filename.toLowerCase();
   const found = new Set<string>();
   // Left-boundary guard is required: plain substring matching on "win" false-positives
@@ -76,7 +100,7 @@ function inferSystems(filename: string): Array<{ type: string }> {
   // Distro names (ubuntu, debian, fedora) are common in CI-built asset names and carry
   // no literal "linux" substring — without this, those assets are silently dropped below.
   if (/linux[-_.]|[-_.]linux|ubuntu|debian|fedora|\.deb$|\.rpm$|\.appimage$/.test(f)) found.add('linux');
-  return [...found].map(type => ({ type }));
+  return [...found].map(type => ({ type, ...inferVersionConstraint(filename, type) }));
 }
 
 // Returns null when the filename indicates an architecture with no corresponding


### PR DESCRIPTION
## Summary

Follow-up to #363, which had to hand-add `min: 7`/`min: 10` to airwin2rack's Windows builds since nothing detected this automatically. This adds that detection to the fetch script, plus AGENTS.md guidance for what still needs a human.

**src/fetch.ts** — new `inferVersionConstraint()`:
- Windows: a `win7`/`windows7`/`win10`/`win11`-style token in the filename → `min` set accordingly (this is what would have auto-generated the `min: 7` from #363)
- macOS: a deployment-target-shaped number next to `mac`/`macos`/`osx` (`macos-10.15.dmg`, `mac-universal-11.dmg`) → `min` set accordingly
- **Default stays "no constraint"** — omitting `min`/`max` means "supports all versions," which must remain the fallback per the user's explicit ask
- Guards against a real false-positive I found while testing: CI-built nightlies dated like `macOS-2026-06-27-abc123.dmg` (both b-step and airwin2rack use this pattern already) would otherwise misread "20" as a macOS version — a digit-boundary check prevents matching a truncated prefix of a longer number
- Linux is intentionally excluded — a distro tag like `ubuntu-20.04` reflects the CI build environment's glibc floor, not a single "Linux OS version" comparable to mac/win version numbers

**AGENTS.md** — documents what the script still can't infer:
- An implicit Windows floor on the "regular" build when it ships alongside a win7-compatible one (often Windows 10, because the current toolchain dropped support for older Windows) — check the CI config for a JUCE-downgrade-style flag, as I did manually for #363
- Requirements stated only in prose ("Requires macOS 11 Big Sur or later")
- The rare case of a genuine upper bound (`max`) — only add one with positive evidence, since a compatibility build is usually a floor, not a ceiling

## Test plan
- [x] `npm run check` passes
- [x] Unit-style tests against real filenames from this session (airwin2rack's `windows7`/regular/arm64ec variants, AIDA-X's `macos-universal-10.15.dmg`, and the date-collision case) — all produce the expected result
- [x] Re-ran the fetch script live against baconpaul/airwin2rack (DAWPlugin release) — the `windows7`-suffixed builds now automatically get `min: 7`, matching what I added by hand in #363, with no false positive on the date-stamped macOS build