### PR TITLE
[Plugin] Add Dexed 1.0.1

### DIFF
--- a/src/plugins/asb2m10/dexed/1.0.1/index.yaml
+++ b/src/plugins/asb2m10/dexed/1.0.1/index.yaml
@@ -1,0 +1,83 @@
+name: Dexed
+author: Pascal Gauthier
+description: Synthesizer closely modeled on the Yamaha DX7.
+license: gpl-3.0
+type: instrument
+tags:
+  - Instrument
+  - Synth
+  - FM
+url: https://github.com/asb2m10/dexed
+audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/asb2m10/dexed/dexed.flac
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/asb2m10/dexed/dexed.jpg
+date: '2025-11-29T18:57:25Z'
+changes: |-
+  Fixes scaling issues from version 0.9.9. We are now with 1.0.x versions so the DAW plugin reported version will follow dexed releases.
+  - Remove default scaling detection
+  - CLAP scaling issue fixed
+  - Assign dialog window to plugin component
+  - Linux binary rebuilt for older glibc versions
+files:
+  - systems:
+      - type: linux
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - clap
+      - elf
+    type: archive
+    size: 7725160
+    sha256: 2bac3d0c4237e8c22c4274b6d5b59fe6329fcae72864f81b5830393eff354fc1
+    url: https://github.com/asb2m10/dexed/releases/download/v1.0.1/Dexed-1.0.1-lnx.zip
+  - systems:
+      - type: mac
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst3
+      - component
+      - clap
+      - app
+    type: installer
+    size: 17183630
+    sha256: a6505103869d15400e7bed1d988d9dd155d6d8204a3d532f5301966ae7507ad8
+    url: https://github.com/asb2m10/dexed/releases/download/v1.0.1/Dexed-1.0.1-macOS.dmg
+  - systems:
+      - type: mac
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst3
+      - component
+      - clap
+      - app
+    type: archive
+    size: 16939688
+    sha256: 4269448bc1312424cafd29aff615d891bc5905ebfc54b42ce70c56b9b10dc401
+    url: https://github.com/asb2m10/dexed/releases/download/v1.0.1/Dexed-1.0.1-macOS.zip
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - clap
+    type: installer
+    size: 11275100
+    sha256: 5dc4e072af90ec54aa0197790b40856e7db1659ff924ed107c7536b442d3584b
+    url: https://github.com/asb2m10/dexed/releases/download/v1.0.1/Dexed-1.0.1-win.exe
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - clap
+      - exe
+    type: archive
+    size: 9742538
+    sha256: 1f118445f2c5c411636bb41ddf8b456db09af74cd38f9ede8a93a01020505f05
+    url: https://github.com/asb2m10/dexed/releases/download/v1.0.1/Dexed-1.0.1-win.zip


### PR DESCRIPTION
Adds version 1.0.1 of Dexed, the Yamaha DX7-compatible FM synthesizer already in the registry (0.9.8).

- Linux: VST3, CLAP, standalone
- macOS: VST3, AU, CLAP, standalone (universal arm64+x64), both the .dmg installer and the raw .zip
- Windows: VST3, CLAP, both the .exe installer and the raw .zip (with standalone exe)

Closes #416