### PR TITLE
[Feature] File upstream tracking issues for packages that fail requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ https://open-audio-stack.github.io/open-audio-stack-registry/<type>/<org-name>/<
 gh repo view <org>/<repo> --json licenseInfo --jq '.licenseInfo'
 ```
 
-The license must be a recognised open-source license (MIT, GPL, Apache, LGPL, AGPL, etc.). If the repository has no license or a proprietary/commercial license, inform the user and stop.
+The license must be a recognised open-source license (MIT, GPL, Apache, LGPL, AGPL, etc.). If the repository has no license or a proprietary/commercial license, inform the user, file/update an upstream tracking issue per [issue-template.md](issue-template.md), and stop.
 
 `licenseInfo`/the GitHub API's `license.key` field is null for repos that don't have a single root `LICENSE` file — including projects using per-file SPDX annotations (a `REUSE.toml` plus a `LICENSES/` folder) or a license file with a nonstandard name. Before concluding "no license", double check:
 
@@ -158,14 +158,20 @@ The repository must have at least one GitHub release containing downloadable bin
 
 **Exception — binaries committed directly to the repository:** If the repository has no releases but ships pre-built binaries committed to the repository itself (common for SFZ sample libraries and similar assets), you may add an entry using a commit-pinned archive URL. See the [Linking to committed binaries](#linking-to-committed-binaries) section of README.md for the required URL format.
 
-If neither condition is met, inform the user and stop.
+If neither condition is met, inform the user, file/update an upstream tracking issue per [issue-template.md](issue-template.md), and stop.
+
+**3f. Filing upstream tracking issues for failures**
+
+Any package that fails 3d (license), 3e (releases/binaries), or the `image` requirement (see [Reviewing and correcting the output](#reviewing-and-correcting-the-output) below) is a candidate for an upstream tracking issue, not just a silent failure. Follow [issue-template.md](issue-template.md) exactly — it already covers deduping (search for the hidden marker before creating anything), editing the issue body in place on re-checks instead of posting comments, and the central tracker on this repo. Don't improvise a different issue format or post ad hoc comments; that file is the single source of truth for this workflow.
+
+Do this for every failing package, single or batch, unless the user has said not to file issues for this run.
 
 If processing a batch, once all URLs have been checked, present a validation table to the user before continuing:
 
-| Package     | Status    | Reason          |
-| ----------- | --------- | --------------- |
-| wolf-shaper | ✅ Ready  |                 |
-| cool-plugin | ❌ Failed | Missing license |
+| Package     | Status    | Reason          | Tracking issue     |
+| ----------- | --------- | --------------- | ------------------ |
+| wolf-shaper | ✅ Ready  |                 |                    |
+| cool-plugin | ❌ Failed | Missing license | org/cool-plugin#42 |
 
 ---
 
@@ -240,7 +246,7 @@ The script is deterministic — it reads only what GitHub's API and the README p
 
 **`image`** — downloaded from the first non-badge image found in the README. External images hosted on third-party sites may block downloads (HTTP 403). If the image is missing, look for one in this order: repo README → repo's `resources`/`assets`/`images`/`docs` folders (an app icon or logo is an acceptable fallback if there's no dedicated screenshot) → the plugin's own website if one is linked. Convert it with: `ffmpeg -i input.png -vf "scale='min(1000,iw)':-1" -q:v 10 output.jpg`. If the source image is transparent (common for logos), composite it onto a solid background first or the plugin will render as a blank white square: `ffmpeg -f lavfi -i "color=c=black:s=WxH" -i logo.png -filter_complex "[0:v][1:v]overlay=(W-w)/2:(H-h)/2:format=auto" -frames:v 1 output.jpg`.
 
-`image` is a **required** field — the validate script will throw and abort if it's missing, not just warn. If, after checking all of the above, no image exists anywhere (no screenshot, no icon, no logo, and the plugin genuinely has no UI to capture), the package cannot be added by automated fetch. Report it to the user as failed with the reason, the same as a licensing or binary-availability failure — don't fabricate a placeholder image.
+`image` is a **required** field — the validate script will throw and abort if it's missing, not just warn. If, after checking all of the above, no image exists anywhere (no screenshot, no icon, no logo, and the plugin genuinely has no UI to capture), the package cannot be added by automated fetch. Report it to the user as failed with the reason, the same as a licensing or binary-availability failure — don't fabricate a placeholder image. File/update an upstream tracking issue per [3f](#3f-filing-upstream-tracking-issues-for-failures) / [issue-template.md](issue-template.md).
 
 **`architectures`** — inferred from asset filenames (e.g. `x64`, `arm64`, `arm64ec`, `arm32`, `m1`). Filenames that give no architecture hint default to `[x64]`. Mac builds that are universal binaries (arm64 + x64) often have no hint in the filename — for `.zip`/`.tar.*` assets the fetch script now extracts the archive and runs `file` on the binary itself to confirm the real architecture(s) automatically; for `.dmg`/`.pkg` installers (which it doesn't extract), check the release notes or README, or download and run `lipo -info` on the binary yourself. If the script couldn't confirm an architecture either way, it prints the file in an "architectures unconfirmed" list at the end — treat every entry there as still defaulted to `[x64]` and needing a manual check, not as verified. There is no registry value for RISC-V (`riscv64`) — the fetch script drops these assets automatically and flags them in its "skipped" list; leave them out rather than mislabeling the architecture.
 
@@ -446,4 +452,4 @@ Then proceed to step 5.
 ## 5. Conclusion
 
 - For a single package, respond to the user that the contribution has been submitted for review, with the url to the PR for them to view VirusTotal scans and peer review.
-- For a batch, respond with a final summary: packages successfully submitted with their individual PR URLs (for VirusTotal scans and peer review), and packages that were skipped or failed with the reason for each.
+- For a batch, respond with a final summary: packages successfully submitted with their individual PR URLs (for VirusTotal scans and peer review), and packages that were skipped or failed with the reason for each. Include the upstream tracking issue URL (see [3f](#3f-filing-upstream-tracking-issues-for-failures)) alongside any failure due to license, releases, or image.

--- a/issue-template.md
+++ b/issue-template.md
@@ -1,0 +1,169 @@
+# External issue template
+
+Template for opening an issue on a **third-party** repo whose package doesn't yet qualify
+for the Open Audio Stack registry (missing license, release binaries, or preview image —
+see [AGENTS.md](AGENTS.md) step 3).
+
+## Usage (agent/maintainer notes — do not post this section)
+
+**Goal: at most one Open Audio Stack issue per repo, ever — and it stays a single
+comment (the issue body) that gets edited in place, never a growing comment thread.**
+New comments notify every subscriber and watcher; editing the body does not. Re-checks
+must never add a comment.
+
+1. **Search before creating.** Every issue this template produces carries a hidden
+   marker comment (`<!-- open-audio-stack-tracker: ... -->`). Before opening a new
+   issue, check whether one already exists:
+
+   ```bash
+   gh issue list --repo <org>/<repo> --state all --search "open-audio-stack-tracker in:body"
+   ```
+
+   - If found → **do not open a new issue and do not post a comment.** Fetch the
+     current body, update it in place (see step 3), and push it back with:
+
+     ```bash
+     gh issue edit <number> --repo <org>/<repo> --body-file <updated-file>
+     ```
+
+   - If not found → use the template below to create a new issue with
+     `gh issue create --body-file <file>`.
+
+2. **One checklist, not one issue per missing item.** Include every outstanding
+   requirement in a single checklist. If a second requirement is discovered later
+   (e.g. license was fine, then a release goes stale), that's an in-place body edit
+   to the same issue, not a new comment or a new issue.
+
+3. **Every re-check edits the body, silently.** On each pass over this repo:
+   - Update `{{LAST_CHECKED}}` to today's date.
+   - Flip any checklist items whose status changed (check off newly-satisfied ones,
+     uncheck any that regressed).
+   - Update or remove the per-item `{{...}}` notes to reflect current findings.
+   - Re-post via `gh issue edit`, never `gh issue comment`.
+
+4. **Check off what's already true.** Only tick a box when verified (e.g. license
+   confirmed present, release confirmed has binaries). Leave genuinely missing items
+   unchecked.
+
+5. **Fully satisfied → close, don't comment.** Once every box is checked and the
+   package has actually been added to the registry, edit the body one last time to
+   say so, then close the issue (`gh issue close`). Closing is a terminal state
+   change the maintainer will want to see; it isn't the noisy part — repeated
+   comments are.
+
+6. **Low-pressure tone.** This is a "when convenient" ask, not a demand — maintainers
+   owe the registry nothing. Always include an easy opt-out.
+
+7. **Fill in every `{{PLACEHOLDER}}`** below, delete this usage section, and post only
+   the `## Template` content as the issue body (the marker comment stays — it's what
+   step 1 searches for next time).
+
+## Template
+
+**Title:**
+
+```
+Add {{PACKAGE_NAME}} to the Open Audio Stack registry
+```
+
+**Body:**
+
+```markdown
+Hello!
+
+We are curating a list of open-source audio software at [Open Audio Stack](https://github.com/open-audio-stack/open-audio-stack-registry). We've created an open registry and package manager for installing/upgrading audio plugins, apps, presets and projects (think npm/Homebrew, but for audio software). We'd like to include **{{PACKAGE_NAME}}**, but it requires a few small changes.
+
+<!-- open-audio-stack-tracker: {{PACKAGE_TYPE}}/{{ORG}}/{{PACKAGE_NAME}} -->
+
+**Requirements checklist:** _(last checked {{LAST_CHECKED}})_
+
+- [ ] License [specified](https://choosealicense.com/appendix/) as a `LICENSE` file, SPDX/REUSE annotations, or a clear statement in the README {{license_note}}
+- [ ] GitHub release with downloadable binaries (zip/tar/exe/dmg/deb — source-only releases don't count), tagged with a fixed date or semantic version {{release_note}}
+- [ ] Preview image in the README or repo — a UI screenshot, or a logo/icon if the project is headless {{image_note}}
+
+{{additional_notes}}
+
+Once everything above is checked off, {{PACKAGE_NAME}} can be added automatically — no further action needed from your side beyond that. If any box looks wrong (e.g. we missed an existing license or image), add a comment to this issue and we'll correct it. And if you'd rather this project not be listed at all, feel free to close this issue — we'll leave it alone.
+
+Thanks!
+```
+
+### Placeholder reference
+
+| Placeholder            | Example                                                |
+| :--------------------- | :----------------------------------------------------- |
+| `{{PACKAGE_NAME}}`     | `liquidsfz`                                            |
+| `{{PACKAGE_TYPE}}`     | `plugins` / `apps` / `presets` / `projects`            |
+| `{{ORG}}`              | `swesterfeld`                                          |
+| `{{LAST_CHECKED}}`     | `2026-07-17` — update every re-check, in place         |
+| `{{license_note}}`     | short clarifier, or delete the whole line if satisfied |
+| `{{release_note}}`     | e.g. `(latest release has no attached binaries)`       |
+| `{{image_note}}`       | e.g. `(no screenshot in README, no icon in assets/)`   |
+| `{{additional_notes}}` | any extra context, or delete if none                   |
+
+## Central tracker (this repo)
+
+One issue on `open-audio-stack/open-audio-stack-registry` aggregates every external
+tracker issue into a single table, so it's possible to see every pending package's
+external issue from one place in the registry, without visiting each repo. The
+external issue itself stays minimal (no outbound links besides the license-list
+reference) — the marker comment is enough for the rebuild step to find it later,
+so there's nothing to add to the posted issue body for this to work.
+
+**Format:** a table, one row per package, regenerated wholesale on each run — not
+hand-edited row by row. Rebuilding from a search is the source of truth; the table
+itself is a derived view, so there's only one place drift can happen (an issue's
+checklist state), not two.
+
+`Package` shows the full `org/repo` path, linked to the repo root (not just the
+package name — some registry slugs use a brand name that differs from the GitHub
+org, see AGENTS.md's `org-name`/`package-name` note, so the repo link is what
+actually lets you navigate there).
+
+`Outstanding` is always a list of unchecked item keywords (`license`, `release`,
+`image`), one per line via `<br>`, even when only one remains — never a prose
+sentence or a comma-separated run-on. Keeping the cell shape identical across
+every row (list in, list out) is what makes the table scannable and easy to
+regenerate mechanically from each issue's checklist state, rather than needing
+per-row special-casing for the single-item case.
+
+`Issue` is a **bare URL**, not a `[text](url)` markdown link. GitHub only expands
+a link into its rich issue-status card (open/closed icon, title) when the URL
+appears unwrapped — custom link text suppresses that autolinking, which defeats
+the point of putting the issue in the table at all.
+
+```markdown
+<!-- open-audio-stack-central-tracker -->
+
+Packages currently blocked on an upstream requirement, tracked one issue per repo
+(see [issue-template.md](issue-template.md)). Rebuilt automatically — don't hand-edit rows.
+
+| Package                                                                 | Type    | Outstanding          | Issue                                                | Last checked |
+| :---------------------------------------------------------------------- | :------ | :------------------- | :--------------------------------------------------- | :----------- |
+| [swesterfeld/liquidsfz](https://github.com/swesterfeld/liquidsfz)       | plugins | `image`              | https://github.com/swesterfeld/liquidsfz/issues/12   | 2026-07-18   |
+| [rullopat/sfizioso-player](https://github.com/rullopat/sfizioso-player) | plugins | `license`<br>`image` | https://github.com/rullopat/sfizioso-player/issues/3 | 2026-07-18   |
+```
+
+**Rebuilding it:**
+
+1. Find every open external tracker issue across GitHub (the marker text is unique
+   enough to search globally, not just within one org):
+
+   ```bash
+   gh search issues "open-audio-stack-tracker in:body" --state open --json repository,number,title,url
+   ```
+
+2. Find the central tracker issue itself:
+
+   ```bash
+   gh issue list --repo open-audio-stack/open-audio-stack-registry --state open --search "open-audio-stack-central-tracker in:body"
+   ```
+
+   If it doesn't exist yet, create it once with `gh issue create` and the marker
+   comment above.
+
+3. For each result from step 1, read its `open-audio-stack-tracker: type/org/name`
+   marker and its checklist state, rebuild the table in full, and push it with
+   `gh issue edit` — never a comment, same as the per-repo issues. Rows for issues
+   that closed (package added, or maintainer opted out) simply drop out of the
+   table on the next rebuild instead of lingering.


### PR DESCRIPTION
## Summary
- Adds `issue-template.md`: a template + workflow for filing a single, low-pressure tracking issue on an upstream repo when a package fails the license, release-binaries, or preview-image requirements. Deduped via a hidden marker comment, edited in place on re-checks (never commented on, to avoid notification spam), and closed once satisfied. Also defines a central tracker issue on this repo that aggregates every pending package into one table.
- Updates `AGENTS.md` to point to `issue-template.md` at each of the three failure points (3d license, 3e releases, and the `image` field check) instead of just reporting the failure and stopping silently, plus adds tracking-issue columns to the batch validation table and final summary.

Test run against a real repo (`jeremysalwen/TalentedHack`, source-only LV2 plugin with no release binaries and no image): jeremysalwen/TalentedHack#13, and the first central tracker at #581.

Closes #417, #577

## Test plan
- [x] Ran the full validation + issue-filing flow manually against `jeremysalwen/TalentedHack` and confirmed both the per-repo and central tracker issues render as intended
- [ ] Maintainer review of wording/tone on a live external issue