### PR TITLE
[Feature] Gate upstream tracking issues on valid content type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,17 @@ If neither condition is met, inform the user, file/update an upstream tracking i
 
 **3f. Filing upstream tracking issues for failures**
 
-Any package that fails 3d (license), 3e (releases/binaries), or the `image` requirement (see [Reviewing and correcting the output](#reviewing-and-correcting-the-output) below) is a candidate for an upstream tracking issue, not just a silent failure. Follow [issue-template.md](issue-template.md) exactly — it already covers deduping (search for the hidden marker before creating anything), editing the issue body in place on re-checks instead of posting comments, and the central tracker on this repo. Don't improvise a different issue format or post ad hoc comments; that file is the single source of truth for this workflow.
+Only file a tracking issue for a repo that already passed 3b (valid plugin/app/preset/project content) and fails purely on 3d (license), 3e (releases/binaries), or the `image` requirement (see [Reviewing and correcting the output](#reviewing-and-correcting-the-output) below) — a genuinely fixable gap. **Never** file one for a repo that fails 3b itself; that's an out-of-scope repo, not a "few small changes" ask. Telling the two apart takes judgment beyond the initial 3b pass, since a repo's one-line description can call itself a "plugin" while its own README says otherwise:
 
-Do this for every failing package, single or batch, unless the user has said not to file issues for this run.
+- **Content type invalid** — a library/framework/source-module meant for embedding (even if some third-party list describes it as "a plugin"), a DAW or full application, a research/training repo with no packaged distributable, or a browser-only tool with no installable artifact at all (no systems/binary concept applies). Read past the one-line description; check what the README actually says the project *is* and how it's meant to be used.
+- **Maintainer disclaims the distributable form** — the README explicitly says a mode is unmaintained/untested/"do not use," or redirects users to a different, already-registered project instead. Treat this the same as failing 3b: the plugin/app form doesn't really exist to package.
+- **Maintainer already opted out** — if the package was previously in the registry and removed at its own maintainer's deliberate request (check recent PRs/commits touching that path), don't re-add or re-file; respect that decision.
+- **GitHub Issues disabled** — `gh repo view <org>/<repo> --json hasIssuesEnabled`, or the failed `gh issue create` call, tells you if filing is even possible. If not, don't silently skip it: still note the package as blocked with a reason of "Issues disabled" in the batch report and the central tracker (see [issue-template.md](issue-template.md)), so it isn't investigated again next run.
+- **Repo appears to belong to the person running this workflow** — if the README, commit history, or contact info points back to the same person operating this registry, flag it to them directly instead of auto-filing an issue against their own repo.
+
+For everything that does qualify, follow [issue-template.md](issue-template.md) exactly — it already covers deduping (search for the hidden marker before creating anything), editing the issue body in place on re-checks instead of posting comments, and the central tracker on this repo. Don't improvise a different issue format or post ad hoc comments; that file is the single source of truth for this workflow.
+
+Do this for every qualifying failed package, single or batch, unless the user has said not to file issues for this run.
 
 If processing a batch, once all URLs have been checked, present a validation table to the user before continuing:
 

--- a/issue-template.md
+++ b/issue-template.md
@@ -11,6 +11,33 @@ comment (the issue body) that gets edited in place, never a growing comment thre
 New comments notify every subscriber and watcher; editing the body does not. Re-checks
 must never add a comment.
 
+0. **Qualify before filing anything.** This template is only for a repo that is
+   genuinely a plugin/app/preset/project (AGENTS.md step 3b) and fails purely on
+   license, releases/binaries, or the image requirement — a real "few small
+   changes" gap. It is **not** for a repo that fails 3b itself. That distinction
+   needs more than the one-line description a batch list gave you — check what
+   the repo's own README says it *is* and how it's meant to be used:
+
+   - A library/framework/source-module meant for embedding into other projects
+     (even if some third-party list calls it "a plugin"), a DAW/full application,
+     a research repo with no packaged distributable, or a browser-only tool with
+     no installable artifact at all — none of these qualify, regardless of
+     license/release/image status.
+   - If the README itself says a standalone/binary mode is unmaintained,
+     untested, "do not use," or redirects users to a different (already
+     registered) project — treat that the same as failing 3b.
+   - If the package was previously in the registry and its own maintainer
+     removed it deliberately, don't re-file. Respect that decision.
+   - If GitHub Issues are disabled on the repo, filing isn't possible at all —
+     don't skip it silently. Note the package as blocked with reason "Issues
+     disabled" in the central tracker instead (see below), so it isn't
+     re-investigated next run.
+   - If the repo appears to belong to the person running this workflow (README,
+     commit history, or contact info points back to them), flag it to them
+     directly instead of auto-filing an issue against their own repo.
+
+   Only once a repo clears this gate do steps 1+ below apply.
+
 1. **Search before creating.** Every issue this template produces carries a hidden
    marker comment (`<!-- open-audio-stack-tracker: ... -->`). Before opening a new
    issue, check whether one already exists:


### PR DESCRIPTION
## Summary
- Adds a qualifying gate to `AGENTS.md` 3f and `issue-template.md`'s usage notes: a tracking issue should only be filed for a repo that already passed 3b (genuinely a plugin/app/preset/project) and fails purely on license, releases/binaries, or image — not for a repo that fails 3b itself.
- Encodes the judgment calls this took by hand while working through issues #417/#419/#521/#522's "didn't qualify" lists: distinguishing a real plugin from a library/source-module meant for embedding, catching maintainer disclaimers ("do not use this mode", redirects to another already-registered project), respecting a maintainer's prior deliberate opt-out, handling repos with GitHub Issues disabled (still surfaced in the central tracker instead of silently skipped), and flagging repos that appear to be the registry maintainer's own project instead of auto-filing against them.

## Test plan
- [x] Applied these exact criteria manually this session against ~15 candidate repos (from #417, #521, #522) before writing them down — excluded SFZero, Calfbox, Zerberus, sfz-web-player, and micro-tcn correctly per this logic, filed for the rest
- [ ] Maintainer review of the gate wording