### PR TITLE
[Fix] Prevent silent truncation/pollution in central tracker rebuild search

### DIFF
--- a/issue-template.md
+++ b/issue-template.md
@@ -173,12 +173,22 @@ Packages currently blocked on an upstream requirement, tracked one issue per rep
 
 **Rebuilding it:**
 
-1. Find every open external tracker issue across GitHub (the marker text is unique
-   enough to search globally, not just within one org):
+1. Find every open external tracker issue across GitHub. `gh search issues` free-text
+   search does **not** do exact-phrase matching — it tokenizes on the hyphens, so
+   past the first ~30 results it starts returning unrelated issues that merely
+   contain "open", "audio", "stack", or "tracker" somewhere. Always pass a high
+   `--limit` (the default silently truncates once the real count exceeds it) *and*
+   filter results down to ones that actually contain the literal marker comment:
 
    ```bash
-   gh search issues "open-audio-stack-tracker in:body" --state open --json repository,number,title,url
+   gh search issues "open-audio-stack-tracker in:body" --state open --limit 100 \
+     --json repository,number,title,url,body \
+     --jq '[.[] | select(.body | test("open-audio-stack-tracker: [^ ]+ -->"))]'
    ```
+
+   If the filtered count comes back at or near whatever `--limit` you passed, raise
+   the limit and re-run — that's a sign of truncation, not a sign you've found
+   everything.
 
 2. Find the central tracker issue itself:
 


### PR DESCRIPTION
## Summary
- `gh search issues "open-audio-stack-tracker in:body"` doesn't do exact-phrase matching on hyphenated text — it tokenizes, so past the default result limit it starts returning unrelated issues that just happen to contain "open"/"audio"/"stack"/"tracker" somewhere (confirmed live: `espressif/esp-idf` and other unrelated repos showed up once `--limit 100` was passed).
- Worse, the *default* limit was silently truncating the real tracked-issue count once it exceeded ~30 — with no error, just fewer rows than actually exist.
- Fixes the documented rebuild command in `issue-template.md` to always pass a high `--limit` and filter results down to ones containing the literal marker comment via `select(test(...))`, plus a note to re-run with a higher limit if the filtered count comes back near the limit passed.

## Test plan
- [x] Reproduced live while rebuilding the central tracker mid-session: default limit missed several real rows (TalentedHack, Yoshimi, HybridReverb2, and others), and `--limit 100` without the phrase filter pulled in unrelated repos
- [x] Confirmed the corrected command (`--limit 100` + `select(test(...))`) returns exactly the real tracked set (37/37) with no false positives