### PR TITLE
[fix] Correct dragonfly-reverb 3.2.10 binaries

### DIFF
--- a/src/plugins/michaelwillis/dragonfly-reverb/3.2.10/index.yaml
+++ b/src/plugins/michaelwillis/dragonfly-reverb/3.2.10/index.yaml
@@ -25,9 +25,9 @@ files:
       - so
       - vst3
     type: archive
-    size: 2267368
-    sha256: 59f1593120de82e31dd194e2ab1536af14fec2b3ec6ec45abf6d9c8ac02ef430
-    url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-linux-x86_64.tar.xz
+    size: 2058296
+    sha256: 6c830ad1b1cc028b0f3c4f4c0a4b073d7193ba1c8783528ed9365df1fc9b23c2
+    url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-linux-arm64.tar.xz
   - systems:
       - type: linux
     architectures:
@@ -42,6 +42,34 @@ files:
     size: 2267368
     sha256: 59f1593120de82e31dd194e2ab1536af14fec2b3ec6ec45abf6d9c8ac02ef430
     url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-linux-x86_64.tar.xz
+  - systems:
+      - type: linux
+    architectures:
+      - arm32
+    contains:
+      - elf
+      - clap
+      - lv2
+      - so
+      - vst3
+    type: archive
+    size: 1727972
+    sha256: f92983910c1d9b039ba7838631f4a3a08917c7dc34eef11e58e331194791a20e
+    url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-linux-armhf.tar.xz
+  - systems:
+      - type: linux
+    architectures:
+      - x32
+    contains:
+      - elf
+      - clap
+      - lv2
+      - so
+      - vst3
+    type: archive
+    size: 2323112
+    sha256: 47e67af4c8a36efd24c9e81aab7db9b610b72581d5fa5e5969dd625ddd01f0b0
+    url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-linux-i686.tar.xz
   - systems:
       - type: mac
     architectures:
@@ -58,6 +86,20 @@ files:
     sha256: e0b854b92a4e51ce5851320fb1a9f91ab1a4309f997de070e175b3e5cab4adaf
     url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-macos-universal.dmg
   - systems:
+      - type: mac
+    architectures:
+      - x64
+    contains:
+      - app
+      - clap
+      - lv2
+      - vst
+      - vst3
+    type: installer
+    size: 12527433
+    sha256: e6e2da2c962d41d46f8359bbd7ec8cff2be79b561539e18d3f73fdc29721bd93
+    url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-macos-intel.dmg
+  - systems:
       - type: win
     architectures:
       - x64
@@ -71,3 +113,17 @@ files:
     size: 22447365
     sha256: ca5f35f9dcd9a33f06490d3c92f04061a1a798cb81257d5ca5851bdda0824c66
     url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-win64.zip
+  - systems:
+      - type: win
+    architectures:
+      - x32
+    contains:
+      - clap
+      - dll
+      - exe
+      - lv2
+      - vst3
+    type: archive
+    size: 16877987
+    sha256: 3a19fb89c7418528cee40b10285aed43c922aae25a9b3f8a801b84546cecf046
+    url: https://github.com/michaelwillis/dragonfly-reverb/releases/download/3.2.10/dragonfly-reverb-3.2.10-win32.zip


### PR DESCRIPTION
## Summary
- The linux arm64 entry incorrectly duplicated the linux x64 entry's url/size/sha256 instead of pointing at the actual arm64 asset
- Added the missing linux armhf, linux i686, macos intel, and windows 32-bit binaries, matching what's published in the [3.2.10 GitHub release](https://github.com/michaelwillis/dragonfly-reverb/releases/tag/3.2.10)
- linux riscv64 and the src tarball were left out since the registry schema has no matching architecture/file type for them

## Test plan
- [x] Downloaded every referenced binary directly from the GitHub release and verified size + sha256 match the yaml