### PR TITLE
[Plugin] Tag LSP Plugins with Nectar 4 modules replaced

### DIFF
--- a/src/plugins/lsp-plugins/lsp-plugins/1.2.33/index.yaml
+++ b/src/plugins/lsp-plugins/lsp-plugins/1.2.33/index.yaml
@@ -6,12 +6,12 @@ type: effect
 tags:
   - Effect
   - Multiband
-  - Modulation
-  - Utility
   - Dynamics
   - Gate
   - Density
   - Phase
+  - De-Esser
+  - Breath Control
 url: https://github.com/lsp-plugins/lsp-plugins
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/lsp-plugins/lsp-plugins/lsp-plugins.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/lsp-plugins/lsp-plugins/lsp-plugins.jpg


### PR DESCRIPTION
Adds De-Esser and Breath Control tags to LSP Plugins per the tagging request in #530 (Nectar 4 Advanced replacements) — this plugin collection covers LSP De-Esser and LSP Gate (breath-control-adjacent gentle expander) from that comparison.

Already at the 8-tag limit, so dropped Modulation and Utility (the two most generic/least-specific existing tags) to make room.