### PR TITLE
[Plugin] Tag Chow Tape Model with Nectar 4 module replaced

### DIFF
--- a/src/plugins/chowdhury-dsp/chowtapemodel/2.11.4/index.yaml
+++ b/src/plugins/chowdhury-dsp/chowtapemodel/2.11.4/index.yaml
@@ -7,6 +7,7 @@ tags:
   - Effect
   - Filter
   - Tape
+  - Saturation
 url: https://github.com/jatinchowdhury18/AnalogTapeModel
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/chowdhury-dsp/chowtapemodel/chowtapemodel.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/chowdhury-dsp/chowtapemodel/chowtapemodel.jpg


### PR DESCRIPTION
Adds a Saturation tag to Chow Tape Model per the tagging request in #530 (Nectar 4 Advanced replacements) — listed there as the closest FOSS replacement for Nectar's Saturation module.