### PR TITLE
[Plugin] Tag Airwindows with Nectar 4 modules replaced

### DIFF
--- a/src/plugins/airwindows/airwindows/1.0.0/index.yaml
+++ b/src/plugins/airwindows/airwindows/1.0.0/index.yaml
@@ -10,6 +10,8 @@ tags:
   - EQ
   - Filter
   - Reverb
+  - Delay
+  - Dimension
 url: https://github.com/airwindows/airwindows
 audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/airwindows/airwindows/airwindows.flac
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/airwindows/airwindows/airwindows.jpg


### PR DESCRIPTION
Adds Delay and Dimension tags to Airwindows per the tagging request in #530 (Nectar 4 Advanced replacements) — listed there as the closest FOSS replacement for Nectar's Delay and Dimension (Chorus/Flanger/Phaser) modules.