### PR TITLE
[Plugin] Tag K-Meter with Insight 2 module replaced

### DIFF
--- a/src/plugins/mzuther/k-meter/2.8.2/index.yaml
+++ b/src/plugins/mzuther/k-meter/2.8.2/index.yaml
@@ -6,6 +6,7 @@ type: tool
 tags:
   - Meter
   - Loudness
+  - Levels
 url: https://github.com/mzuther/K-Meter
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/mzuther/k-meter/k-meter.jpg
 date: '2020-04-18T15:09:54Z'


### PR DESCRIPTION
Adds a Levels tag to K-Meter per the tagging request in #531 (Insight 2 replacements) — listed there as a FOSS alternative for Insight's Levels (True Peak / VU / K-weighted) module.