### PR TITLE
[Plugin] Tag traKmeter with Insight 2 module replaced

### DIFF
--- a/src/plugins/mzuther/trakmeter/2.4.7/index.yaml
+++ b/src/plugins/mzuther/trakmeter/2.4.7/index.yaml
@@ -6,6 +6,7 @@ type: tool
 tags:
   - Meter
   - Loudness
+  - Levels
 url: https://github.com/mzuther/traKmeter
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/mzuther/trakmeter/trakmeter.jpg
 date: '2020-04-19T19:54:17Z'


### PR DESCRIPTION
Adds a Levels tag to traKmeter per the tagging request in #531 (Insight 2 replacements) — listed there as a FOSS alternative for Insight's Levels (True Peak / VU / K-weighted) module.