### PR TITLE
[Plugin] Tag InstaWidth with Insight 2 module replaced

### DIFF
--- a/src/plugins/hariel1985/instawidth/1.0.0/index.yaml
+++ b/src/plugins/hariel1985/instawidth/1.0.0/index.yaml
@@ -6,6 +6,7 @@ type: effect
 tags:
   - Stereo Width
   - Mid/Side
+  - Sound Field
 url: https://github.com/hariel1985/InstaWidth
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/hariel1985/instawidth/instawidth.jpg
 date: '2026-05-17T05:06:41Z'


### PR DESCRIPTION
Adds a Sound Field tag to InstaWidth per the tagging request in #531 (Insight 2 replacements) — listed there as a FOSS alternative for Insight's Sound Field (Vectorscope / Goniometer / Correlation) module.