### PR TITLE
[Plugin] Tag ZL Equalizer 2 with Insight 2 module replaced

### DIFF
--- a/src/plugins/zl-audio/zlequalizer2/1.2.2/index.yaml
+++ b/src/plugins/zl-audio/zlequalizer2/1.2.2/index.yaml
@@ -9,6 +9,7 @@ tags:
   - Sculptor
   - Unmask
   - Tonal Balance Control
+  - Spectrum Analyzer
 url: https://zl-audio.github.io/plugins/zlequalizer2/
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/zl-audio/zlequalizer2/zlequalizer2.jpg
 date: '2026-06-27T11:31:18Z'


### PR DESCRIPTION
Adds a Spectrum Analyzer tag to ZL Equalizer 2 per the tagging request in #531 (Insight 2 replacements) — listed there as a FOSS alternative for Insight's Spectrum Analyzer module, via its built-in FFT analyzer.