### PR TITLE
[Plugin] Update IEM Plugin Suite to 1.15.0

### DIFF
--- a/src/plugins/audioplugins/iempluginsuite/1.15.0/index.yaml
+++ b/src/plugins/audioplugins/iempluginsuite/1.15.0/index.yaml
@@ -1,0 +1,60 @@
+name: IEM Plugin Suite
+author: Institute of Electronic Music and Acoustics
+description: Collection of ambisonic plug-ins including Compressors, Delays, Reverb, Encoders, Decoders and Visualizers.
+license: gpl-3.0
+type: effect
+tags:
+  - Effect
+  - Reverb
+  - Delay
+  - Surround
+url: https://git.iem.at/audioplugins/IEMPluginSuite
+audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/audioplugins/iempluginsuite/iempluginsuite.flac
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/audioplugins/iempluginsuite/iempluginsuite.jpg
+date: '2025-04-10T10:56:49.000Z'
+changes: |
+  - Moved to JUCE 8.0.7
+  - Added VST3 and AAX support (macOS and Windows)
+  - Make more plug-ins resizeable
+  - DualDelay: major refactor, sync with DAW BPM, tap button
+  - FdnReverb: high-pass filter, bigger FDN sizes, freeze mode
+  - SceneRotator: native support for Supperware Head Tracker 1
+files:
+  - systems:
+      - type: mac
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst
+      - vst3
+      - lv2
+      - aax
+      - app
+    type: installer
+    size: 450994338
+    sha256: eec673eedb219e4733b2c888beec4df50343aacf6b2305c5f430e0cb02e90088
+    url: https://users.iem.at/holzmueller/IEM-Audioplugins/IEMPluginSuite/v1.15.0/IEMPluginSuite_v1.15.0.pkg
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - dll
+      - vst3
+      - lv2
+      - aax
+    type: installer
+    size: 49939801
+    sha256: 3673e98b10af32e4ff4f0915b10fc48c5ff822d46d9a26eac89fae3c439b0664
+    url: https://users.iem.at/holzmueller/IEM-Audioplugins/IEMPluginSuite/v1.15.0/IEMPluginSuiteInstaller_v1.15.0_x64.exe
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - exe
+    type: archive
+    size: 65266109
+    sha256: 6918d0fab678281017cd3980d5c1ea75e39649511cac9dac2fdae0ec882871cc
+    url: https://users.iem.at/holzmueller/IEM-Audioplugins/IEMPluginSuite/v1.15.0/IEMPluginSuite_v1.15.0_x64_standalones.zip


### PR DESCRIPTION
Updates IEM Plugin Suite from 1.14.1 to 1.15.0, sourced manually from IEM's own GitLab (git.iem.at) since this isn't a GitHub-hosted project — the fetch script doesn't apply here.

Adds a Surround tag per the tagging request in #531 (Insight 2 replacements) — the suite's bundled EnergyVisualizer plugin was listed there as a FOSS alternative for Insight's Multichannel/Surround metering.

Notes on the file data:
- macOS: verified as a genuine universal binary (arm64 + x86_64) by expanding the `.pkg` and inspecting the actual VST3 binary with `lipo -info`, not just trusting the release notes' "universal installer" wording.
- Windows: split into two release assets now (an installer with VST/VST3/LV2/AAX, and a separate standalone .zip) vs. the single zip in 1.14.1 — confirmed via the release notes text after both `innoextract` and `7z` failed to open the newer Inno Setup 6.4.2 installer.
- No Linux binary included — IEM only publishes Linux builds via an unstable per-build GitLab CI artifact URL (job ID changes every build), so there's nothing safe to pin, same as the prior 1.14.1 entry.
- Caught and fixed a self-inflicted checksum mismatch during validation: my first download of the ~430MB macOS `.pkg` was silently truncated by a 120s background-command timeout, so the sha256/size in this PR come from the validator's own recompute against a confirmed-complete download.