### PR TITLE
[Plugin] Add Guitar Strum Sequencer 1.1.1

### DIFF
--- a/src/plugins/allenloves/guitarstrumsequencer/1.1.1/index.yaml
+++ b/src/plugins/allenloves/guitarstrumsequencer/1.1.1/index.yaml
@@ -1,0 +1,43 @@
+name: Guitar Strum Sequencer
+author: Allen SC Wu
+description: A 16-step MIDI FX plugin that turns held chords into realistic, string-by-string guitar strumming patterns using a chord voicing engine.
+license: mit
+type: effect
+tags:
+  - Guitar
+  - MIDI
+  - Sequencer
+  - Arpeggiator
+  - Chord
+url: https://github.com/allenloves/GuitarStrumSequencer
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/allenloves/guitarstrumsequencer/guitarstrumsequencer.jpg
+date: '2026-07-27T09:41:51Z'
+changes: |-
+  - macOS builds are now universal (arm64 + x86_64); v1.1.0 was arm64-only
+  - Standalone app is now included in the macOS archive
+  - Added an MIT LICENSE file to the repository
+  - Fixed the plugin version reported to hosts, which was stuck at 1.0.0
+files:
+  - systems:
+      - type: mac
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst3
+      - component
+      - app
+    type: archive
+    size: 11878407
+    sha256: 0b5a3a210fbc34aecccacb7fcbb6ea71fb9c32977e8d09b0485d3fce89f8c9c8
+    url: https://github.com/allenloves/GuitarStrumSequencer/releases/download/v1.1.1/GuitarStrumSequencer-macOS.zip
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - vst3
+    type: archive
+    size: 2875294
+    sha256: 482b2b8c86b25aa30665900e1707eac21e089449f124c66a00664d4008a94a97
+    url: https://github.com/allenloves/GuitarStrumSequencer/releases/download/v1.1.1/GuitarStrumSequencer-Windows.zip


### PR DESCRIPTION
Adds Guitar Strum Sequencer 1.1.1, following up on #618.

This release fixes the two problems raised in that PR:

- The macOS build is now a genuine universal binary (`arm64` + `x86_64`). v1.1.0 shipped arm64-only despite the release notes claiming otherwise, so it would not load on Intel Macs. Verified with `lipo -archs` on all three bundles in the published archive.
- The Standalone app is now included in the macOS archive; it was built but never packaged. The entry's `contains` reflects this (`vst3`, `component`, `app`).

Also added an MIT `LICENSE` file to the repository (it was previously only stated in the README), and fixed the plugin version reported to hosts, which had been stuck at `1.0.0`.

One deliberate change from the 1.1.0 entry: `type` is `effect` rather than `generator`. The plugin transforms incoming MIDI rather than producing material on its own, so `effect` describes it better. Flagging it so the difference doesn't look like a fetch error.

Generated with `npm run dev:fetch`, then reviewed: description taken from the 1.1.0 entry, tags set manually (the repo has no GitHub topics), and `changes` trimmed to a plain bullet list. `npm run check` passes.