### PR TITLE
[fix] Smarter image/license/platform detection in dev:fetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,24 @@ If check finds a match that is the same version code, **stop**. If the match is 
 https://open-audio-stack.github.io/open-audio-stack-registry/<type>/<org-name>/<package-name>
 ```
 
+**This only checks already-merged entries — it says nothing about an open, unmerged PR already adding the same package from a different source list or an earlier run.** Always also check open PRs before generating any files:
+
+```bash
+gh pr list --repo open-audio-stack/open-audio-stack-registry --search "<repo-or-plugin-name>" --state all
+```
+
+Do this per-package, not once at the start of a batch — a name collision found this way (two unrelated source lists both containing the same upstream repo) isn't something the directory/grep check above will ever catch.
+
+**Fork of an existing/abandoned repo is not automatically a duplicate.** If the candidate repo is a fork (`gh repo view <org>/<repo> --json isFork,parent --jq '{isFork, parent: .parent.nameWithOwner}'`), check whether it has actually diverged before assuming it's redundant with its parent or with an already-registered entry for the parent:
+
+```bash
+gh api repos/<fork-org>/<fork-repo>/compare/<parent-org>:<branch>...<fork-org>:<branch> --jq '{ahead: .ahead_by, behind: .behind_by}'
+```
+
+A fork with its own commits ahead of a dormant/unmaintained parent (0 behind, N ahead, and its own releases the parent never had) is a legitimate active continuation, not a copy — note the lineage in the PR description for the human reviewer rather than skipping it. A fork with 0 ahead, or one that exists solely to feed a bundler (see 3f), is not.
+
+**One repo can bundle several genuinely distinct, independently-released plugins.** Check the release tags before assuming a repo maps to a single registry package — if they're prefixed differently per component (`shear-v1.2.0`, `tilt-v1.0.0`, ...) rather than all sharing one name, the README's own plugin list is the source of truth for what's actually in the repo, and each one needs its own `dev:fetch` run (with the tag specified), its own branch, and its own PR — never combine them into one entry named after the repo.
+
 **3d. Free open-source license**
 
 ```bash
@@ -152,6 +170,12 @@ The license must be a recognised open-source license (MIT, GPL, Apache, LGPL, AG
 ```bash
 gh api repos/<org>/<repo>/contents --jq '.[].name' | grep -i licen
 gh api repos/<org>/<repo>/contents/REUSE.toml --jq '.content' | base64 -d   # if a LICENSES/ folder exists
+```
+
+`license.key` also comes back as the literal string `other` (not null) fairly often — GitHub's classifier is similarity-based and misses non-canonical wording (e.g. a short "licensed under GPLv3" copyright header instead of the full FSF boilerplate) even when a real, unambiguous open-source license is right there in the file. The fetch script (see below) now handles this automatically: when the API reports empty/`other`, it fetches the actual `LICENSE` file's text and pattern-matches it, flagging the result in the "Fields requiring review" section for you to confirm rather than silently trusting either the API's `other` or its own guess. If you're checking by hand instead, don't stop at `license.key: "other"` — read the actual file:
+
+```bash
+gh api repos/<org>/<repo>/license --jq '.content' | base64 -d | head -20
 ```
 
 **3e. Has releases with binary builds**
@@ -228,7 +252,7 @@ The script automatically:
 
 - Derives `org-name` and `package-name` from the GitHub URL in kebab-case
 - Fetches repo metadata: name, description, license, topics/tags
-- Finds and downloads a preview image from the README, converting it to JPEG (max 1000px, 70% quality)
+- Finds a preview image (README first, then a full repo-tree scan if the README has none), preferring an actual screenshot over a logo/banner/video-thumbnail, and downloads it as JPEG (max 1000px), compositing transparent sources onto a neutral background first
 - Finds and downloads a demo audio file from the README, converting it to a 10-second FLAC clip
 - Fetches the latest (or specified) release assets with sizes and SHA256 hashes
 - Infers systems, architectures, and plugin formats from asset filenames and README text
@@ -261,7 +285,7 @@ The script is deterministic — it reads only what GitHub's API and the README p
 
 **`audio`** — only populated if the README contains a direct link to an audio file. Most READMEs do not. If no audio is found, source a demo clip manually, convert to FLAC (`ffmpeg -i input -t 10 -c:a flac output.flac`), and place it at `src/plugins/org-name/package-name/package-name.flac`.
 
-**`image`** — downloaded from the first non-badge image found in the README. External images hosted on third-party sites may block downloads (HTTP 403). If the image is missing, look for one in this order: repo README → repo's `resources`/`assets`/`images`/`docs` folders (an app icon or logo is an acceptable fallback if there's no dedicated screenshot) → the plugin's own website if one is linked. Convert it with: `ffmpeg -i input.png -vf "scale='min(1000,iw)':-1" -q:v 10 output.jpg`. If the source image is transparent (common for logos), composite it onto a solid background first or the plugin will render as a blank white square: `ffmpeg -f lavfi -i "color=c=black:s=WxH" -i logo.png -filter_complex "[0:v][1:v]overlay=(W-w)/2:(H-h)/2:format=auto" -frames:v 1 output.jpg`.
+**`image`** — the fetch script first scans the README for a non-badge image (excluding CI badges, sponsor buttons, and demo-video thumbnails), preferring one whose filename/path looks like an actual screenshot (contains "screenshot", "preview", "ui", etc.) over the first match — a "watch the demo" video thumbnail earlier in the README no longer wins by default just for appearing first. If the README has no image at all, it scans the whole repo tree in one call (not a fixed list of directory names) and applies the same screenshot-hint preference, so nested/unconventional locations (`Source/Assets/Screenshot.jpg`, `ScreenShots/`, a bare root-level file) are found automatically. Transparent source images (common for a logo used as a fallback when there's no dedicated screenshot) are composited onto a neutral mid-grey background automatically before converting to JPEG — safe for fully opaque images too, since the background is completely covered either way. External images hosted on third-party sites may still block downloads (HTTP 403); if so, or if you want a different image than what was auto-picked, download and convert manually: `ffmpeg -i input.png -vf "scale='min(1000,iw)':-1" -q:v 10 output.jpg` (add the grey-background composite from `downloadAndConvertImage` in `src/fetch.ts` if the source has transparency).
 
 `image` is a **required** field — the validate script will throw and abort if it's missing, not just warn. If, after checking all of the above, no image exists anywhere (no screenshot, no icon, no logo, and the plugin genuinely has no UI to capture), the package cannot be added by automated fetch. Report it to the user as failed with the reason, the same as a licensing or binary-availability failure — don't fabricate a placeholder image. File/update an upstream tracking issue per [3f](#3f-filing-upstream-tracking-issues-for-failures) / [issue-template.md](issue-template.md).
 
@@ -396,6 +420,8 @@ gh release download v1.0.2 --repo wolf-plugins/wolf-shaper --pattern "filename.z
 shasum -a 256 /tmp/filename.zip
 wc -c < /tmp/filename.zip
 ```
+
+**Always take `size` from the downloaded archive's own bytes (`wc -c`/`ls -la` above, or the GitHub API's `assets[].size`) — never from a number glimpsed inside an archive listing.** If you're inspecting a zip's contents by hand (e.g. `unzip -l` to figure out the platform because fetch reported "no system/platform recognized"), it prints the _uncompressed_ length of each entry — easy to mistake for the zip's own size, and `npm run dev:validate` will fail with a size mismatch if you do. The zip file itself, not anything inside it, is what gets hashed and measured.
 
 For reference on all allowed file fields and format values:
 

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -79,6 +79,36 @@ function slugToTitleCase(slug: string): string {
     .join(' ');
 }
 
+// ── License detection ──────────────────────────────────────────────────────────
+
+// GitHub's license detector is a similarity classifier, not a human — it regularly comes back
+// `other`/null for a repo that ships a perfectly standard license under an unusual filename, with
+// extra project-specific header lines, or phrased as a short "under the terms of the GNU GPL v3"
+// notice rather than the full canonical block. When that happens, fetch the LICENSE file's own
+// text and pattern-match it directly. Order matters: AGPL/LGPL are checked before plain GPL since
+// their canonical text contains "General Public License" as a substring too.
+function detectLicenseFromText(text: string): string | null {
+  const t = text.slice(0, 4000); // license identification only needs the opening section
+  const has = (re: RegExp) => re.test(t);
+  if (has(/BSD Zero-?Clause License/i)) return '0bsd';
+  if (has(/unencumbered software released into the public domain/i)) return 'unlicense';
+  if (has(/DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE/i)) return 'wtfpl';
+  if (has(/CC0 1\.0 Universal|Creative Commons Zero/i)) return 'cc0-1.0';
+  if (has(/Permission to use, copy, modify, and\/?or distribute this software for any purpose with or without fee/i))
+    return 'isc';
+  if (has(/Apache License[\s\S]{0,40}Version 2\.0/i)) return 'apache-2.0';
+  if (has(/Mozilla Public License[\s\S]{0,20}2\.0/i)) return 'mpl-2.0';
+  if (has(/GNU Affero General Public License/i)) return has(/version 3/i) ? 'agpl-3.0' : null;
+  if (has(/GNU Lesser General Public License/i))
+    return has(/version 3/i) ? 'lgpl-3.0' : has(/version 2\.1/i) ? 'lgpl-2.1' : null;
+  if (has(/GNU General Public License/i)) return has(/version 3/i) ? 'gpl-3.0' : has(/version 2/i) ? 'gpl-2.0' : null;
+  if (has(/Redistributions of source code must retain[\s\S]*Redistributions in binary form/i))
+    return has(/Neither the name/i) ? 'bsd-3-clause' : 'bsd-2-clause';
+  if (has(/This software is provided ['"]as-is['"], without any express or implied warranty/i)) return 'zlib';
+  if (has(/Permission is hereby granted, free of charge, to any person obtaining a copy/i)) return 'mit';
+  return null;
+}
+
 // ── Version normalisation (mirrors upgrade.ts) ────────────────────────────────
 
 function versionNormalize(tag: string): string {
@@ -446,6 +476,13 @@ interface ArchiveInspection {
 // filtered out so they don't get misidentified as (or dilute confidence in) the real one.
 const HELPER_BINARY_PATTERN = /unins|uninstall|vc_?redist|dotnetfx|dotnet-|winsparkle|crashpad|updater?\b|setup/i;
 
+// Release assets that are never a plugin/app binary themselves — checksum manifests, signature
+// files, and plain-text/doc sidecars a release commonly ships alongside the real downloads.
+// Excluded outright rather than run through system/format inference, which would otherwise
+// occasionally misfire and tag one of these with a `contains` value (seen with a
+// `SHA256SUMS-macOS.txt` that got auto-tagged `contains: [vst3]`).
+const NON_BINARY_ASSET_PATTERN = /^SHA(256|1|512)SUMS|^CHECKSUMS|\.(txt|md|sig|asc|sha256|sha1|pem|crt|yml|yaml)$/i;
+
 function inspectExtractedDir(dir: string): ArchiveInspection {
   const result: ArchiveInspection = {
     platforms: new Set(),
@@ -485,8 +522,12 @@ function inspectExtractedDir(dir: string): ArchiveInspection {
   // Inspect real binaries for platform/architecture — `file` reads magic bytes, so this is
   // authoritative even when directory/file names give no hint at all.
   try {
+    // Bundle payload binaries (e.g. a Windows VST3's actual PE32 DLL, which conventionally
+    // keeps the bundle's own name + ".vst3" extension rather than ".dll") are matched by
+    // name here too — zip extraction routinely drops the executable bit for these, so relying
+    // on -perm +111 alone leaves them invisible to `file` and the platform undetected entirely.
     const candidates = execSync(
-      `find "${dir}" -type f \\( -name "*.dylib" -o -name "*.so" -o -name "*.dll" -o -name "*.exe" -o -perm +111 \\)`,
+      `find "${dir}" -type f \\( -name "*.dylib" -o -name "*.so" -o -name "*.dll" -o -name "*.exe" -o -name "*.vst3" -o -name "*.component" -o -name "*.clap" -o -name "*.lv2" -o -perm +111 \\)`,
       { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
     )
       .split('\n')
@@ -580,29 +621,45 @@ function inferPluginType(description: string, topics: string[], readme: string):
 
 // ── Image finder ──────────────────────────────────────────────────────────────
 
+// Matches non-content images (CI badges, sponsor buttons) and video-thumbnail links some
+// READMEs use for a "watch the demo" button — both regularly outrank the real UI screenshot
+// if picked by first-match-wins alone (e.g. a YouTube thumbnail sitting a few lines above the
+// actual screenshot, which is otherwise textually identical to a normal markdown image).
+const IMAGE_URL_EXCLUDE = /badge|shield|ko-?fi|travis|action|workflow|codecov|img\.youtube\.com|ytimg\.com/i;
+// A URL/path containing one of these is very likely an actual UI screenshot rather than a
+// logo, banner, or demo-video thumbnail — used to rank candidates, never to filter them out.
+const SCREENSHOT_HINT = /screenshot|preview|screen[-_]?shot|\bui\b|\bgui\b|interface/i;
+
 async function findImageUrl(org: string, repo: string, branch: string, readme: string): Promise<string | null> {
-  const imageUrls = [
+  const readmeCandidates = [
     ...[...readme.matchAll(/!\[[^\]]*\]\(([^)]+\.(?:png|jpe?g|gif|webp)[^)]*)\)/gi)].map(m => m[1]),
     ...[...readme.matchAll(/<img[^>]+src=["']([^"']+\.(?:png|jpe?g|gif|webp))/gi)].map(m => m[1]),
-  ].filter(u => !/badge|shield|ko-?fi|travis|action|workflow|codecov/i.test(u));
+  ].filter(u => !IMAGE_URL_EXCLUDE.test(u));
 
-  if (imageUrls.length > 0) {
-    const url = imageUrls[0];
+  if (readmeCandidates.length > 0) {
+    // First match isn't necessarily the best one — e.g. a "watch the demo" video thumbnail
+    // often appears before the real screenshot. Prefer whichever candidate's path/filename
+    // looks like an actual screenshot; fall back to the first match otherwise.
+    const url = readmeCandidates.find(u => SCREENSHOT_HINT.test(u)) ?? readmeCandidates[0];
     if (/^https?:\/\//.test(url)) return url;
     return `https://raw.githubusercontent.com/${org}/${repo}/refs/heads/${branch}/${url.replace(/^\.\//, '')}`;
   }
 
-  for (const dir of ['docs/img', 'docs', 'screenshots', 'assets', 'images', '.github']) {
-    try {
-      const contents: any[] = ghJson(`api repos/${org}/${repo}/contents/${dir}`);
-      const imgs = contents.filter((f: any) => /\.(png|jpe?g)$/i.test(f.name) && f.download_url);
-      if (imgs.length > 0) {
-        const preferred = imgs.find((f: any) => /screenshot|preview|screen|plugin|ui/i.test(f.name));
-        return (preferred ?? imgs[0]).download_url;
-      }
-    } catch {
-      /* directory doesn't exist */
+  // README has no image at all — scan the whole repo tree in one call rather than guessing a
+  // fixed list of directory names. Real repos use all sorts of conventions (Source/Assets,
+  // ScreenShots, docs/img, a bare root-level file, ...) and GitHub's contents API is
+  // case-sensitive, so a short hardcoded directory list misses most of them.
+  try {
+    const treeData = ghJson(`api repos/${org}/${repo}/git/trees/${branch}?recursive=1`);
+    const imgs = (treeData.tree as any[]).filter(
+      (f: any) => f.type === 'blob' && /\.(png|jpe?g|gif|webp)$/i.test(f.path) && !IMAGE_URL_EXCLUDE.test(f.path),
+    );
+    if (imgs.length > 0) {
+      const preferred = imgs.find((f: any) => SCREENSHOT_HINT.test(f.path)) ?? imgs[0];
+      return `https://raw.githubusercontent.com/${org}/${repo}/refs/heads/${branch}/${preferred.path}`;
     }
+  } catch {
+    /* tree lookup failed (empty repo, rate limit, etc.) — treat as no image found */
   }
   return null;
 }
@@ -615,7 +672,17 @@ async function downloadAndConvertImage(url: string, destPath: string): Promise<v
   if (!res.ok) throw new Error(`HTTP ${res.status} fetching image`);
   writeFileSync(tmp, Buffer.from(await res.arrayBuffer()));
   try {
-    execSync(`ffmpeg -i "${tmp}" -vf "scale='min(1000,iw)':-1" -q:v 10 -update 1 "${destPath}" -y`, { stdio: 'pipe' });
+    // JPEG has no alpha channel, so a source PNG with any transparency (a logo/icon on a
+    // transparent background, common for repos with no dedicated screenshot) would otherwise
+    // flatten onto plain black — often invisible for a dark-lined logo. Composite onto neutral
+    // mid-grey instead: a no-op for fully opaque sources (the top image completely occludes it)
+    // and readable regardless of whether the transparent art itself is light or dark.
+    // scale2ref sizes the solid-colour background to match the source image without needing to
+    // know its dimensions ahead of time.
+    execSync(
+      `ffmpeg -i "${tmp}" -f lavfi -i color=c=0x808080:s=4x4 -filter_complex "[1:v][0:v]scale2ref[bg][img];[bg][img]overlay=format=auto,scale='min(1000,iw)':-1" -q:v 10 -frames:v 1 -update 1 "${destPath}" -y`,
+      { stdio: 'pipe' },
+    );
   } finally {
     execSync(`rm -f "${tmp}"`);
   }
@@ -683,7 +750,21 @@ async function main() {
     `repo view ${ghOrg}/${ghRepo} --json name,description,homepageUrl,licenseInfo,repositoryTopics,defaultBranchRef`,
   );
   const branch: string = repoInfo.defaultBranchRef?.name ?? 'main';
-  const license: string = repoInfo.licenseInfo?.key ?? '';
+  let license: string = repoInfo.licenseInfo?.key ?? '';
+  let licenseDetectedFromText = false;
+  if (!license || license === 'other') {
+    try {
+      const licenseFile = ghJson(`api repos/${ghOrg}/${ghRepo}/license`);
+      const licenseText = Buffer.from(licenseFile.content, 'base64').toString();
+      const detected = detectLicenseFromText(licenseText);
+      if (detected) {
+        license = detected;
+        licenseDetectedFromText = true;
+      }
+    } catch {
+      /* no license file GitHub could find at all — leave as-is */
+    }
+  }
   const topics: string[] = (repoInfo.repositoryTopics ?? []).map((t: any) => t.name ?? t.topic?.name).filter(Boolean);
 
   // README
@@ -710,6 +791,8 @@ async function main() {
   const ambiguousStandaloneBinaries: string[] = [];
   const cleanupPaths: string[] = [];
   for (const asset of release.assets as any[]) {
+    if (NON_BINARY_ASSET_PATTERN.test(asset.name)) continue;
+
     let systems = inferSystems(asset.name);
 
     const archResult = inferArchitectures(asset.name);
@@ -885,6 +968,10 @@ async function main() {
   console.log('\n─── Generated YAML (please review) ───\n');
   process.stdout.write(yamlContent);
   console.log('\n─── Fields requiring review ───');
+  if (licenseDetectedFromText)
+    console.log(
+      `  license: "${license}"  — GitHub's API reported no license/"other"; detected from the LICENSE file's own text, verify`,
+    );
   console.log(`  name:    "${pkg.name}"  — confirm display name matches plugin branding`);
   console.log(`  type:    "${pkg.type}"  — confirm: instrument / effect / sampler / generator / tool`);
   const nonTitleCaseTags = (pkg.tags as string[]).filter(t => t !== slugToTitleCase(t));


### PR DESCRIPTION
## Summary
Found while batch-adding ~40 plugins to the registry this week (crshrprt starred-repo triage). Four fixes to `src/fetch.ts`, all tested against real repos with no regressions on previously-working cases:

- **Image discovery**: ranks README-embedded images by screenshot-like filename/path instead of first-match-wins (was picking a YouTube demo thumbnail over the real screenshot on `dfl/faveworm`), excludes video thumbnails alongside the existing badge/shield exclusion, and replaces the old 6-directory hardcoded fallback with a single recursive repo-tree scan — finds images in any nested or unconventionally-named folder (`Source/Assets/`, `ScreenShots/`, etc.) instead of guessing directory names.
- **Transparent-image compositing**: `downloadAndConvertImage` now composites onto a neutral grey background before JPEG conversion. A transparent logo (common as a fallback image when there's no dedicated screenshot) previously rendered as a solid black square — verified zero visual change for fully-opaque sources.
- **VST3/AU/CLAP/LV2 bundle platform detection**: the archive inspector now also matches bundle-payload binaries by their own extension (`*.vst3`, `*.component`, `*.clap`, `*.lv2`), not just `*.dll`/`*.exe`/`*.so` plus the executable-permission bit. Root cause of 7 "no system/platform recognized" failures in one batch this week — Windows VST3 binaries conventionally keep the bundle's own name+extension and lose the executable bit on zip extraction, so `file` never even ran on them before.
- **License fallback**: when GitHub's API reports empty/`other`, fetches the actual `LICENSE` file and pattern-matches its text against common licenses, flagging the result for manual confirmation rather than either trusting `other` or guessing silently.
- **Non-binary asset filtering**: `SHA256SUMS*`, `*.txt`, `*.sig`, etc. are now excluded up front instead of occasionally getting a bogus `contains` value (seen on `EyalDelarea/Cycloscope`).

Also updates `AGENTS.md`: codifies the open-PR check (a real duplicate slipped through in batch 1 without it), a fork ahead/behind check before assuming duplicate, awareness that one repo can bundle several independently-released plugins, and the "size/sha256 from actual downloaded bytes, never an archive listing" rule (I made that exact mistake once this week). Also brings the `image` field description in line with fetch.ts's new actual behavior.

## Test plan
- [x] `npm run check` (lint/build/test) passes
- [x] Re-ran `dev:fetch` against `OTODESK4193/GlitchNexus`, `ChordMatrix`, `OtodeskSampler` — all now correctly detect Windows/x64/vst3 instead of failing with "no system/platform recognized"
- [x] Re-ran against `dfl/faveworm` — now picks the real UI screenshot automatically instead of a YouTube thumbnail
- [x] Re-ran against `mm-rnd/Kiln` — transparent logo now composites onto grey instead of rendering black, and is found via tree-scan without needing the README reference
- [x] Re-ran against `subhankardas15071992-cloud/protoplug` and `008takeshi/Drawwave-Vocoder` — license now correctly detected as `mit`/`gpl-3.0` instead of `other`
- [x] Re-ran against `EyalDelarea/Cycloscope` — `SHA256SUMS-*.txt` assets no longer produce bogus file entries
- [x] Regression-checked previously-working repos (`chsh2/SlowSampler2`, `hollance/krunch`) — unchanged output