### PR TITLE
[plugin] Update The Mono Hawk tags to match GitHub topics

### DIFF
--- a/src/plugins/nilace/themonohawk/0.1.0/index.yaml
+++ b/src/plugins/nilace/themonohawk/0.1.0/index.yaml
@@ -4,14 +4,14 @@ description: Chromatic tuner for guitar and bass on Linux (LV2)
 license: gpl-3.0
 type: tool
 tags:
-  - Ardour
-  - Audio
-  - Audio Plugin
   - Bass
   - Chromatic Tuner
-  - DSP
   - Guitar
+  - Instrument Tuner
   - LV2
+  - Pitch Detection
+  - Pitch Tracking
+  - Realtime Audio
 url: https://github.com/NiLace/TheMonoHawk
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/nilace/themonohawk/themonohawk.jpg
 date: '2026-06-20T13:22:42Z'


### PR DESCRIPTION
## Summary
- The Mono Hawk author retagged the upstream repo (https://github.com/NiLace/TheMonoHawk) with: `chromatic-tuner`, `instrument-tuner`, `lv2`, `pitch-detection`, `pitch-tracking`, `realtime-audio`
- Updated `src/plugins/nilace/themonohawk/0.1.0/index.yaml` tags to reflect these, adding `Instrument Tuner`, `Pitch Detection`, `Pitch Tracking`, `Realtime Audio`
- Dropped `Ardour` (not a GitHub topic and not used as a tag anywhere else in the registry) and `Audio`/`Audio Plugin`/`DSP` (generic, not GitHub topics) to stay within the 8-tag limit — kept `Bass` and `Guitar` since they're called out in the plugin description

## Test plan
- [x] `npm run dev:validate -- src/plugins/nilace/themonohawk/0.1.0/index.yaml` passes