### PR TITLE
[fix] Two more dev:fetch bugs found in batch 6

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -88,7 +88,10 @@ function slugToTitleCase(slug: string): string {
 // text and pattern-match it directly. Order matters: AGPL/LGPL are checked before plain GPL since
 // their canonical text contains "General Public License" as a substring too.
 function detectLicenseFromText(text: string): string | null {
-  const t = text.slice(0, 4000); // license identification only needs the opening section
+  // Collapse whitespace (including hard line-wraps at ~80 columns, extremely common in
+  // LICENSE files) before matching — a fingerprint phrase spanning a wrap point otherwise
+  // silently fails to match even though the license text is a byte-for-byte standard copy.
+  const t = text.slice(0, 4000).replace(/\s+/g, ' ');
   const has = (re: RegExp) => re.test(t);
   if (has(/BSD Zero-?Clause License/i)) return '0bsd';
   if (has(/unencumbered software released into the public domain/i)) return 'unlicense';
@@ -424,7 +427,16 @@ function extractArchive(tmpFile: string, filename: string): string | null {
   try {
     if (/\.zip$/i.test(filename)) {
       mkdirSync(dir, { recursive: true });
-      execSync(`unzip -oq "${tmpFile}" -d "${dir}"`, { stdio: 'pipe' });
+      try {
+        execSync(`unzip -oq "${tmpFile}" -d "${dir}"`, { stdio: 'pipe' });
+      } catch {
+        // unzip exits 1 for warnings it still recovers from — e.g. "appears to use backslashes
+        // as path separators" (routine for Windows-built zips) — with the archive otherwise
+        // fully extracted. Swallow here and let the dirHasFiles check below be the real signal,
+        // same as every other archive type in this function; letting this propagate to the
+        // outer catch previously discarded a real, complete extraction over a mere warning,
+        // silently falling back to unreliable prose-based format inference instead.
+      }
       expandNestedPkgs(dir); // zip may wrap a .pkg rather than shipping raw bundles
     } else if (/\.tar\.gz$|\.tgz$/i.test(filename)) {
       mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
## Summary
Two more `dev:fetch` fixes found while continuing the plugin-batching effort (follow-up to #665):

- **unzip exit-code-1 warnings discarded a complete extraction.** `kevin-jenkins/PlugNspectr`'s Windows zip triggered unzip's "appears to use backslashes as path separators" warning (routine for Windows-built zips) — a non-fatal warning, but `execSync` throws on any non-zero exit, so `extractArchive` bailed via its outer catch and returned `null` even though the archive was fully extracted. This silently skipped real archive-content inspection in favor of unreliable release-body text matching, which incorrectly tagged the file `contains: [vst3, component]` — the release notes mentioned "AU" only in a sentence about a future macOS build, not this Windows asset. Fixed by swallowing the unzip call's exit code and relying on the existing `dirHasFiles()` check as the true success signal, matching every other archive type already handled this way in the same function.
- **License fingerprint matching failed on line-wrapped LICENSE files.** `n0emo/hyperclip`'s LICENSE is byte-for-byte standard MIT, but hard-wrapped at ~80 columns split "obtaining a copy" across a line break — the regex required a literal space, so it silently didn't match. Now collapses whitespace (including newlines) before matching.

## Test plan
- [x] `npm run check` passes
- [x] Re-ran `dev:fetch` against `kevin-jenkins/PlugNspectr` — now correctly reports `contains: [vst3]` only, matching the actual zip contents (verified by mounting/extracting it manually)
- [x] Re-ran against `n0emo/hyperclip` — license now correctly detected as `mit`
- [x] Regression-checked `OTODESK4193/GlitchNexus`, `EyalDelarea/Cycloscope`, `subhankardas15071992-cloud/protoplug`, `008takeshi/Drawwave-Vocoder` — all unchanged