### PR TITLE
[plugin] Update Dynamo0C tags to match GitHub topics

### DIFF
--- a/src/plugins/nilace/dynamo0c/1.2.0/index.yaml
+++ b/src/plugins/nilace/dynamo0c/1.2.0/index.yaml
@@ -4,14 +4,14 @@ description: Console-style 4-band parametric EQ — an LV2 plugin for Linux with
 license: gpl-3.0
 type: effect
 tags:
-  - Ardour
   - Audio
   - Audio Plugin
   - DSP
   - EQ
-  - Equalizer
-  - Linux Audio
+  - Filter
+  - Linux
   - LV2
+  - Parametric EQ
 url: https://github.com/NiLace/Dynamo0C
 image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/nilace/dynamo0c/dynamo0c.jpg
 date: '2026-07-17T08:16:47Z'


### PR DESCRIPTION
## Summary
- Dynamo0C author retagged the upstream repo (https://github.com/NiLace/Dynamo0C) with: `dsp`, `eq`, `lv2`, `parametric-eq`, `filter`, `linux`
- Updated `src/plugins/nilace/dynamo0c/1.2.0/index.yaml` tags to reflect these, adding `Filter`, `Linux`, `Parametric EQ`
- Dropped `Ardour` (not a GitHub topic and not used as a tag anywhere else in the registry — same issue found on the sibling `nilace/themonohawk` entry), and consolidated `Equalizer`/`Linux Audio` into the GitHub-topic-aligned `EQ`/`Linux` to stay within the 8-tag limit

## Test plan
- [x] `npm run dev:validate -- src/plugins/nilace/dynamo0c/1.2.0/index.yaml` passes