### PR TITLE
[fix] inferSystems false-positive matching "mac" inside longer words

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -169,7 +169,11 @@ function inferSystems(filename: string): Array<{ type: string; min?: number }> {
   // side must allow a digit too ("win32", "win64" have no separator before the number).
   // "w32"/"w64" is a shorthand some CI configs use in place of the full "win32"/"win64".
   if (/(?<![a-z])win(?:dows)?(?=[-_.0-9]|$)|\.exe$|\.msi$/.test(f) || tok('w(?:32|64)').test(f)) found.add('win');
-  if (/mac(os)?[-_.]|[-_.]mac(os)?|darwin|\.dmg$|\.pkg$/.test(f) || tok('osx').test(f)) found.add('mac');
+  // Same left+right boundary discipline as "win" above — without a right boundary, "mac"
+  // as a bare prefix false-positives inside any longer word starting with those three
+  // letters that happens to follow a separator, e.g. "time-machine_linux-x64.tar.xz"
+  // matching on "-mac" from "-machine" and wrongly tagging a Linux-only asset as also Mac.
+  if (/(?<![a-z])mac(?:os)?(?=[-_.0-9]|$)|darwin|\.dmg$|\.pkg$/.test(f) || tok('osx').test(f)) found.add('mac');
   // Distro names (ubuntu, debian, fedora) are common in CI-built asset names and carry
   // no literal "linux" substring — without this, those assets are silently dropped below.
   // "lin"/"lin64"/"lin32" is a shorthand some CI configs use in place of "linux".


### PR DESCRIPTION
## Summary
`inferSystems`'s mac-detection regex required a separator immediately *before* "mac"/"macos" but placed no constraint on what follows it — so any word starting with those letters, right after a separator, matched too. The neighboring "win" pattern already has this right-boundary check (with a code comment specifically calling out "darwin" as a known false-positive risk for "win"); the "mac" pattern was missing the equivalent protection.

Found via [maksut/midi-time-machine](https://github.com/maksut/midi-time-machine): its Linux-only release asset `midi-time-machine_linux-x64-v0.0.1.tar.xz` and Windows-only `midi-time-machine_windows-x64-v0.0.1.zip` both picked up a spurious extra `mac` system entry, because `-mac` is a substring of `-machine`. This made both files look like they were also valid macOS downloads, when the real macOS builds are entirely separate release assets.

## Changes
- `mac(?:os)?` gains the same `(?=[-_.0-9]|$)` right-boundary lookahead (and an explicit left-boundary lookbehind) that `win` already uses.

## Test plan
- [x] `npx prettier --check`, `npx eslint`, `npx tsc --noEmit` all clean
- [x] `npx vitest run` — 7/7 passing
- [x] Re-ran `dev:fetch` against `maksut/midi-time-machine` and confirmed each asset now gets only its real platform(s)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>