### PR TITLE
[fix] Convert GitHub file-viewer (blob) image URLs to raw content URLs

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -704,6 +704,14 @@ async function findImageUrl(org: string, repo: string, branch: string, readme: s
     // often appears before the real screenshot. Prefer whichever candidate's path/filename
     // looks like an actual screenshot; fall back to the first match otherwise.
     const url = readmeCandidates.find(u => SCREENSHOT_HINT.test(u)) ?? readmeCandidates[0];
+    // A README image is sometimes authored as the GitHub *file viewer* URL
+    // (github.com/org/repo/blob/branch/path) rather than a raw content link — an easy mistake,
+    // since that's the URL the browser's address bar shows when you navigate to the file. It
+    // still starts with "https://" so it would otherwise pass straight through as "already a
+    // full URL", but fetching it returns GitHub's HTML page wrapper, not the image bytes.
+    const blobMatch = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)$/);
+    if (blobMatch)
+      return `https://raw.githubusercontent.com/${blobMatch[1]}/${blobMatch[2]}/refs/heads/${blobMatch[3]}/${blobMatch[4]}`;
     if (/^https?:\/\//.test(url)) return url;
     return `https://raw.githubusercontent.com/${org}/${repo}/refs/heads/${branch}/${url.replace(/^\.\//, '')}`;
   }


### PR DESCRIPTION
## Summary
`findImageUrl` already converts relative README image paths (`./img/foo.png`) to `raw.githubusercontent.com` URLs, but treated any URL already starting with `https://` as ready to use as-is. A README image authored as the GitHub *file viewer* URL — `github.com/org/repo/blob/branch/path` — still starts with `https://`, but fetching it returns GitHub's HTML page wrapper, not the actual image bytes. This is an easy, common authoring mistake: that's exactly the URL a browser's address bar shows when viewing a file on GitHub, so it's natural to paste it into a README by hand.

`downloadAndConvertImage`'s fetch gets a 200 response with HTML content, fails to decode it as an image, and the whole image step silently reports "not found" — the plugin then needs a manual image download to unblock (`image` is a required field).

Found via [powerpcme/Prism](https://github.com/powerpcme/Prism), whose README links its screenshot with `https://github.com/powerpcme/Prism/blob/main/Images/screenshot.png`.

## Changes
- `findImageUrl` now detects `github.com/<org>/<repo>/blob/<branch>/<path>` URLs specifically and rewrites them to the equivalent `raw.githubusercontent.com` URL before returning, same as the relative-path case.

## Test plan
- [x] `npx prettier --check`, `npx eslint`, `npx tsc --noEmit` all clean
- [x] `npx vitest run` — 7/7 passing
- [x] Re-ran `dev:fetch` against `powerpcme/Prism` and confirmed the image now downloads and converts correctly with no manual intervention

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>