### PR TITLE
Add HTek Distortion 0.1.1

### DIFF
--- a/src/plugins/christoskonstantas/htekdistortion/0.1.1/index.yaml
+++ b/src/plugins/christoskonstantas/htekdistortion/0.1.1/index.yaml
@@ -1,0 +1,24 @@
+name: HTek Distortion
+author: kiztam
+description: Piecewise, memoryless soft-knee hard clipper with a monotonic quartic transition between the linear and saturated regions, plus optional bias and DC compensation
+license: mit
+type: effect
+tags:
+  - Distortion
+  - Clipper
+  - Soft Knee
+url: https://github.com/ChristosKonstantas/HTekDistortion
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/christoskonstantas/htekdistortion/htekdistortion.jpg
+date: '2026-08-15T10:09:38Z'
+changes: Fix soft-knee transfer curve to preserve monotonicity and prevent foldback by replacing the previous smoothstep-based transition with a monotonic C2 quartic curve.
+files:
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - vst3
+    type: archive
+    size: 6517760
+    sha256: 09b3d9163c7a3658bf20d66a98798442da76328c12295cbe7ed6a3235300989a
+    url: https://github.com/ChristosKonstantas/HTekDistortion/releases/download/v0.1.1/HTekDistortion.vst3


### PR DESCRIPTION
Adds HTekDistortion v0.1.1.

This patch release fixes the soft-knee transfer curve by replacing the previous smoothstep-based transition with a monotonic C<sup>2</sup> quartic curve, preventing foldback/non-monotonic behaviour in the knee region.

No plugin parameters or interface have changed.