### PR TITLE
Fix versioned .so libraries being mistaken for a Linux standalone binary

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -609,8 +609,10 @@ function inspectExtractedDir(dir: string): ArchiveInspection {
         result.platforms.add('linux');
         // Linux CLAP/VST2 plugins are a single flat ELF file (unlike the directory bundles
         // used by vst3/component/lv2), so they'd otherwise slip past inBundle() and look like
-        // a standalone candidate — exclude by extension instead.
-        if (!inBundle(f) && !HELPER_BINARY_PATTERN.test(path.basename(f)) && !/\.(so|clap)$/i.test(f))
+        // a standalone candidate — exclude by extension instead. Shared libraries following the
+        // SONAME convention (libfoo.so.1.17.3) keep a version suffix after ".so", so a bare
+        // ".so$" check misses them and they get mistaken for a second standalone candidate.
+        if (!inBundle(f) && !HELPER_BINARY_PATTERN.test(path.basename(f)) && !/\.(so(\.\d+)*|clap)$/i.test(f))
           linuxStandaloneCandidates.push(path.relative(dir, f));
       }
     }


### PR DESCRIPTION
`inspectExtractedDir`'s Linux standalone-candidate exclusion only matched a bare `.so` suffix, so a SONAME-versioned shared library like `libonnxruntime.so.1.17.3` (the standard Linux packaging convention for shipping multiple ABI versions side by side) wasn't excluded — it got counted as a second 'standalone candidate' alongside the real binary, so `inspectExtractedDir` gave up ("ambiguous standalone binaries") instead of auto-tagging `elf`, and the caller fell back to unreliable README-text inference for the `contains` field.

Verified against flarkflarkflark/AudioRestorationVST's Linux Standalone.zip (real binary `Vinyl Restoration Suite` + `libonnxruntime.so` + `libonnxruntime.so.1.17.3`): before the fix, `contains` fell back to `[vst3]` (wrong — the README mentions VST3 as one of several build formats, but this archive is standalone-only); after the fix, it's correctly identified as `[elf]` with no ambiguity warning.

Checks run: prettier, eslint, tsc --noEmit, vitest (7/7 pass).