### PR TITLE
Exclude the Steinberg VST-compatible trademark badge from image detection

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -697,7 +697,12 @@ function inferPluginType(description: string, topics: string[], readme: string):
 // READMEs use for a "watch the demo" button — both regularly outrank the real UI screenshot
 // if picked by first-match-wins alone (e.g. a YouTube thumbnail sitting a few lines above the
 // actual screenshot, which is otherwise textually identical to a normal markdown image).
-const IMAGE_URL_EXCLUDE = /badge|shield|ko-?fi|travis|action|workflow|codecov|img\.youtube\.com|ytimg\.com/i;
+// steinbergmedia.github.io/vst3_dev_portal is the official "VST Compatible" trademark logo
+// asset many JUCE/VST3 plugin READMEs embed near the top (required by Steinberg's branding
+// terms) — its filename carries no "badge"/"shield" hint, but it's exactly that: a compliance
+// badge, not a screenshot, and it otherwise wins as the first README image every time.
+const IMAGE_URL_EXCLUDE =
+  /badge|shield|ko-?fi|travis|action|workflow|codecov|img\.youtube\.com|ytimg\.com|steinbergmedia\.github\.io/i;
 // A URL/path containing one of these is very likely an actual UI screenshot rather than a
 // logo, banner, or demo-video thumbnail — used to rank candidates, never to filter them out.
 const SCREENSHOT_HINT = /screenshot|preview|screen[-_]?shot|\bui\b|\bgui\b|interface/i;


### PR DESCRIPTION
`findImageUrl`'s README-image detection took the first matching `<img>`/markdown-image URL, filtered only by `IMAGE_URL_EXCLUDE` (badge/shield/ko-fi/CI/YouTube-thumbnail patterns). The official Steinberg "VST Compatible" trademark logo — hosted at `steinbergmedia.github.io/vst3_dev_portal`, which many JUCE/VST3 plugin READMEs embed near the top per Steinberg's branding requirements — doesn't match any of those keywords in its URL/filename, so it kept winning as the README's first image and outranking the real UI screenshot embedded further down.

Verified against davemollen/dm-Fuzz: before the fix, the generic VST-compatible badge was picked; after the fix, the real pedal-UI screenshot (`lv2/dm-Fuzz.lv2/modgui/screenshot-dm-fuzz.png`) is picked instead. Also hit identically on GullDSP/Circulate-VST in the previous batch (fixed by hand there since the fix didn't exist yet) — likely to recur across the rest of this batch's `davemollen/dm-*` repos, which share the same README template and all support VST3.

Checks run: prettier, eslint, tsc --noEmit, vitest (7/7 pass).