### PR TITLE
Exclude .sh/.json release assets from binary inference

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -545,8 +545,12 @@ const HELPER_BINARY_PATTERN = /unins|uninstall|vc_?redist|dotnetfx|dotnet-|winsp
 // files, and plain-text/doc sidecars a release commonly ships alongside the real downloads.
 // Excluded outright rather than run through system/format inference, which would otherwise
 // occasionally misfire and tag one of these with a `contains` value (seen with a
-// `SHA256SUMS-macOS.txt` that got auto-tagged `contains: [vst3]`).
-const NON_BINARY_ASSET_PATTERN = /^SHA(256|1|512)SUMS|^CHECKSUMS|\.(txt|md|sig|asc|sha256|sha1|pem|crt|yml|yaml)$/i;
+// `SHA256SUMS-macOS.txt` that got auto-tagged `contains: [vst3]`). `.sh`/`.json` build/install
+// helper scripts hit the exact same failure: a name like `build-osx.sh` or `mac_installer.sh`
+// carries an OS-name substring that `inferSystems` happily matches, so a handful-of-bytes shell
+// script ends up with a full systems/architectures/contains entry guessed from README text.
+const NON_BINARY_ASSET_PATTERN =
+  /^SHA(256|1|512)SUMS|^CHECKSUMS|\.(txt|md|sig|asc|sha256|sha1|pem|crt|yml|yaml|sh|json)$/i;
 
 function inspectExtractedDir(dir: string): ArchiveInspection {
   const result: ArchiveInspection = {


### PR DESCRIPTION
Build/install helper scripts (`build-osx.sh`, `build-linux.sh`, `mac_installer.sh`, ...) that happen to carry an OS-name substring in their filename get matched by `inferSystems`'s win/mac/linux detection the same as a real binary would. Since these tiny scripts obviously don't extract as an archive and don't match any plugin-format keyword by filename, `contains` falls through to the README-text guess — producing a bogus file entry (e.g. a 1.4KB `mac_installer.sh` tagged `contains: [vst3]`) for something that was never a plugin binary at all.

This is the exact same failure mode `NON_BINARY_ASSET_PATTERN` already exists to prevent (its own comment cites a `SHA256SUMS-macOS.txt` that got auto-tagged `vst3` the same way) — just missing `.sh`/`.json` from the excluded extensions.

Verified against giulioz/jv880_juce, whose `latest` release ships `build-osx.sh`/`build-linux.sh`/`build-win.sh`/`mac_installer.sh` alongside the real binaries: before the fix, all four scripts got bogus `contains: [vst3]` file entries (plus two flagged as "architecture unconfirmed"); after the fix, they're correctly excluded and only the 5 real binary assets remain.

Checks run: prettier, eslint, tsc --noEmit, vitest (7/7 pass).