### PR TITLE
[app] Add PPsVaultTracker 1.1.1-beta

### DIFF
--- a/src/apps/gptpps/ppsvaulttracker/1.1.1-beta/index.yaml
+++ b/src/apps/gptpps/ppsvaulttracker/1.1.1-beta/index.yaml
@@ -1,0 +1,24 @@
+name: PPsVaultTracker
+author: PPsRetroVault
+description: A modern VSTi tracker with FT2 heritage, VST3 plugin hosting, and MIDI + stems export
+license: agpl-3.0
+type: tool
+tags:
+  - Tracker
+  - VSTi
+  - MIDI
+  - Retro
+url: https://github.com/gPTPPs/ppsvaulttracker
+image: https://open-audio-stack.github.io/open-audio-stack-registry/apps/gptpps/ppsvaulttracker/ppsvaulttracker.jpg
+date: '2026-08-15T09:48:26Z'
+changes: 'Bug-fix release. New, Open, Import and Quit now confirm before replacing unsaved work, and untitled sessions are snapshotted every 3 minutes and offered back at startup. No project format change: .ubt folders stay compatible with 1.1.0-beta.'
+files:
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    type: archive
+    open: PPsVaultTracker-1.1.1-beta-win64/PPsVaultTracker.exe
+    size: 4871186
+    sha256: 5d7cd92ed6de477499f819b978d0737a4fc28f51ead6d50c0bd961b2fb3af20e
+    url: https://github.com/gPTPPs/ppsvaulttracker/releases/download/v1.1.1-beta/PPsVaultTracker-1.1.1-beta-win64.zip


### PR DESCRIPTION
Adds the 1.1.1-beta release of PPsVaultTracker, following up on #644 and #666. I'm the author (gPTPPs / PPsRetroVault).

Bug-fix release only, no metadata change beyond the version: same `type: tool`, same tags, same image. The archive still contains no plugin format, just the standalone executable and its libopenmpt DLLs, so it stays under `src/apps` with the `open:` field.

`npm run dev:validate` passes (exit 0), with size and sha256 confirmed against the downloaded asset. The three remaining notices (no Linux, Mac or arm64 build) are the same informational ones the 1.1.0-beta entry already carries.

---

Unrelated, but worth reporting while I'm here: `src/validate.ts` line 20 splits the incoming path with `path.sep`, so on Windows a path written with forward slashes never splits — including the exact form used in AGENTS.md's own example:

```
npm run dev:validate -- src/<type>/org-name/package-name/1.0.0/index.yaml
```

`subPath` ends up empty, `slug` and `version` come back `undefined`, the report line prints `✓ undefined/undefined/undefined`, and the run then dies at line 41:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.join (node:path:513:7)
    at <anonymous> (src/validate.ts:41:38)
```

Passing backslashes works, which is how the validation above was run. Splitting on `/[\\/]/` instead of `path.sep` would make the documented command work as written on every platform. Happy to open a separate PR for it if that's useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
