### PR TITLE
Fix bare 'x86' filename token defaulting to 32-bit instead of 64-bit

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -203,9 +203,17 @@ function inferArchitectures(filename: string): { archs: string[] | null; confide
   if (/arm64|aarch64|[-_]m[123][-_.]|apple[._-]?silicon/.test(f) || tok('arm').test(f))
     return { archs: ['arm64'], confident: true };
   if (/armhf|armv7|arm32/.test(f)) return { archs: ['arm32'], confident: true };
-  if (/x86[_-]64|amd64|64[-_]?bit/.test(f) || tok('x64').test(f)) return { archs: ['x64'], confident: true };
-  if (/i[3-6]86|32[-_]?bit|win32/.test(f) || (tok('x86').test(f) && !/[-_]64/.test(f)) || tok('x32').test(f))
-    return { archs: ['x32'], confident: true };
+  // Bare "x86" (no i386/i686/32bit/win32 qualifier) is ambiguous by name alone, but in
+  // practice release filenames overwhelmingly use it to mean x86-64 now, not 32-bit — e.g.
+  // ZL-Audio's "*-Linux-x86.zip" ships an x86_64-linux VST3 binary. Only tokens that
+  // unambiguously signal 32-bit route to the x32 branch below.
+  if (
+    /x86[_-]64|amd64|64[-_]?bit/.test(f) ||
+    tok('x64').test(f) ||
+    (tok('x86').test(f) && !/i[3-6]86|32[-_]?bit|win32/.test(f))
+  )
+    return { archs: ['x64'], confident: true };
+  if (/i[3-6]86|32[-_]?bit|win32/.test(f) || tok('x32').test(f)) return { archs: ['x32'], confident: true };
   return { archs: ['x64'], confident: false }; // safe default; flag for review if no hint found
 }
 


### PR DESCRIPTION
## Summary
- \`inferArchitectures()\` routed bare \`x86\` (no \`i386\`/\`i686\`/\`32bit\`/\`win32\` qualifier) to the 32-bit branch, but real-world release filenames overwhelmingly use bare \`x86\` to mean x86-64 today.
- Found via ZL-Audio/ZLSplitter: \`ZL.Splitter-0.3.0-Linux-x86.zip\` and \`ZL.Splitter-0.3.0-Windows-x86.msi\` both ship x86_64 binaries (confirmed with \`file(1)\` on the extracted VST3 \`.so\`/installer contents — path even reads \`x86_64-linux\` internally), but were being tagged \`x32\`.
- Fix: bare \`x86\` now only routes to \`x32\` when the filename also lacks any 32-bit-specific signal; otherwise it's treated the same as \`x64\`/\`x86_64\`/\`amd64\`.

## Test plan
- [x] \`npx prettier --check src/fetch.ts\`
- [x] \`npx eslint src/fetch.ts\`
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (7 passed)
- [x] Re-ran \`npx tsx src/fetch.ts https://github.com/ZL-Audio/ZLSplitter\` before/after — Linux/Windows \`x86\`-named assets now correctly report \`x64\` instead of \`x32\`