### PR TITLE
Strip markdown image title syntax before using README image URL

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -736,8 +736,12 @@ const IMAGE_URL_EXCLUDE =
 const SCREENSHOT_HINT = /screenshot|preview|screen[-_]?shot|\bui\b|\bgui\b|interface/i;
 
 async function findImageUrl(org: string, repo: string, branch: string, readme: string): Promise<string | null> {
+  // Markdown image syntax allows an optional title after the URL, e.g. `![alt](url "title")`
+  // — without stripping it, the greedy `[^)]*` tail captures the title text too, corrupting
+  // the URL (seen on MichaelHurst97/Noizier, whose 404'd image fetch was actually this).
+  const stripMarkdownTitle = (u: string) => u.replace(/\s+["'][^"']*["']$/, '');
   const readmeCandidates = [
-    ...[...readme.matchAll(/!\[[^\]]*\]\(([^)]+\.(?:png|jpe?g|gif|webp)[^)]*)\)/gi)].map(m => m[1]),
+    ...[...readme.matchAll(/!\[[^\]]*\]\(([^)]+\.(?:png|jpe?g|gif|webp)[^)]*)\)/gi)].map(m => stripMarkdownTitle(m[1])),
     ...[...readme.matchAll(/<img[^>]+src=["']([^"']+\.(?:png|jpe?g|gif|webp))/gi)].map(m => m[1]),
   ].filter(u => !IMAGE_URL_EXCLUDE.test(u));
 


### PR DESCRIPTION
## Summary
- Markdown image syntax allows an optional title after the URL: \`![alt](url "title")\`.
- The README-scanning regex's greedy \`[^)]*\` tail captured that trailing \` "title"\` text as part of the URL itself, corrupting it before the blob→raw conversion (or a direct fetch).
- Found via MichaelHurst97/Noizier, whose README embeds \`![Noizier Screenshot](https://github.com/MichaelHurst97/Noizier/blob/main/Assets/Noizier_Screenshot.PNG "Noizier Screenshot")\` — the constructed raw URL ended up with the quoted title still attached, so the image fetch 404'd even though the real file exists and is reachable directly.
- Fix: strip a trailing whitespace + quoted-title suffix from the captured URL before using it.

## Test plan
- [x] \`npx prettier --check src/fetch.ts\`
- [x] \`npx eslint src/fetch.ts\`
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (7 passed)
- [x] Re-ran \`npx tsx src/fetch.ts https://github.com/MichaelHurst97/Noizier\` before/after — image fetch changed from "skipped (HTTP 404)" to a successful download of the real screenshot