### PR TITLE
Add ZL Equalizer 2 v1.3.1

### DIFF
--- a/src/plugins/zl-audio/zlequalizer2/1.3.1/index.yaml
+++ b/src/plugins/zl-audio/zlequalizer2/1.3.1/index.yaml
@@ -1,0 +1,122 @@
+name: ZL Equalizer 2
+author: ZL Audio
+description: Dynamic equalizer plugin.
+license: agpl-3.0
+type: effect
+tags:
+  - Effect
+  - Equalizer
+  - Sculptor
+  - Unmask
+  - Tonal Balance Control
+  - Spectrum Analyzer
+url: https://zl-audio.github.io/plugins/zlequalizer2/
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/zl-audio/zlequalizer2/zlequalizer2.jpg
+date: '2026-08-15T12:38:02Z'
+changes: "Mostly UI fixes :) And the preset manager!\r\n\r\nAfter installation, please load the plugin in an empty DAW session and check its functionality.\r\n\r..."
+files:
+  - systems:
+      - type: linux
+    architectures:
+      - arm64
+    contains:
+      - vst3
+      - lv2
+      - elf
+    type: archive
+    size: 10255980
+    sha256: 9a9c0a1ec5a6160f9811fa163687f8fec89218a6759f4564250932e2fee79d3e
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-Linux-arm64.zip
+  - systems:
+      - type: linux
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - lv2
+      - elf
+    type: archive
+    size: 11200659
+    sha256: f6638907703fa6b7ebeabeb4f37874781a94233060165ff2c13bf69b088f7a1e
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-Linux-x86-64-AVX2.zip
+  - systems:
+      - type: linux
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - lv2
+      - elf
+    type: archive
+    size: 10734404
+    sha256: 40b2de10d636910ca418f314394aecdac9a7ce2cd6066f7d2eda27011f94f1b1
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-Linux-x86-64.zip
+  - systems:
+      - type: mac
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst3
+      - component
+      - aax
+      - app
+    type: installer
+    size: 14492688
+    sha256: dba5b278c4c4ba70e58b90130cc4a828fbd7e90f26cc96d2d927821bd5ca7d1a
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-macOS-arm64.dmg
+  - systems:
+      - type: mac
+    architectures:
+      - x64
+      - arm64
+    contains:
+      - vst3
+      - component
+      - aax
+      - app
+    type: installer
+    size: 16299778
+    sha256: 96f201059308717b38609249caca8cc7ddb74b3f6496812a90c743b45ca57ab9
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-macOS-x86-64.dmg
+  - systems:
+      - type: win
+    architectures:
+      - arm64
+    contains:
+      - vst3
+      - lv2
+    type: installer
+    size: 8933376
+    sha256: 75a820009b5ffdbbabc217a8a0e3a087f0913003cb2bc58b757c95a5d02ef046
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-Windows-arm64.msi
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - lv2
+    type: installer
+    size: 13164544
+    sha256: cceb114ec04bab8f2810b4ebe7e7b93911f7525aff5fa9eb6593e7bbbc671dca
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-Windows-x86-64-AVX2.msi
+  - systems:
+      - type: win
+    architectures:
+      - x64
+    contains:
+      - vst3
+      - lv2
+    type: installer
+    size: 12693504
+    sha256: cc514e2786d0218d5afc44d4e565d095e08607fbe6bbbfabbdb6bacfcac7259d
+    attested: true
+    url: https://github.com/ZL-Audio/ZLEqualizer/releases/download/1.3.1/ZL.Equalizer.2-1.3.1-Windows-x86-64.msi


### PR DESCRIPTION
New version of the already-registered ZL Equalizer 2. Adds filters beyond Nyquist, an All Pass filter type, EQ match built-in target curves, and fixes several bugs (static gain compensation display, loudness matching, audio glitches after EQ match, a crash with dynamic Flat Tilt).