### PR TITLE
fix(fetch): filter plural "-plugins" topic variants from tags

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -81,7 +81,7 @@ async function checkAttestation(org: string, repo: string, sha256: string): Prom
 // Filtering known-technical topics out before slicing to 8 means more of those slots land on
 // something semantically useful, without changing the reviewer's job of double-checking tags.
 const TECHNICAL_TOPIC_RE =
-  /^(vst|vst2|vst3(-plugin)?|vst-plugin|clap(-plugin)?|lv2(-plugin)?|au|au-plugin|aax(-plugin)?|ladspa(-plugin)?|dssi|dpf|juce(-.*)?|jsfx|faust(-dsp)?|standalone|audio-plugin|audio-unit|plugin|plugins|cli|sdk|api|library|framework|cross-platform|linux|windows|macos|osx|cmake|c|cpp|c-plus-plus|rust|python|typescript|javascript|nodejs|wasm|webassembly)$/;
+  /^(vst|vst2|vst3(-plugins?)?|vst-plugins?|clap(-plugins?)?|lv2(-plugins?)?|au|au-plugins?|aax(-plugins?)?|ladspa(-plugins?)?|dssi|dpf|juce(-.*)?|jsfx|faust(-dsp)?|standalone|audio-plugins?|audio-unit|plugin|plugins|cli|sdk|api|library|framework|cross-platform|linux|windows|macos|osx|cmake|c|cpp|c-plus-plus|rust|python|typescript|javascript|nodejs|wasm|webassembly)$/;
 
 function slugToTitleCase(slug: string): string {
   return slug


### PR DESCRIPTION
## Summary
- `TECHNICAL_TOPIC_RE` only matched singular `-plugin` suffixes (e.g. `vst3-plugin`, `clap-plugin`), so GitHub topics using the plural form (`vst-plugins`, `lv2-plugins`, `clap-plugins`, `ladspa-plugins`, `vst3-plugins`, `audio-plugins`) weren't filtered and crowded out descriptive tags.
- Found via `SpotlightKid/faustfilters`, whose topics are all pluralized (`ladspa-plugins`, `vst-plugins`, `lv2-plugins`, `vst3-plugins`, `clap-plugins`), only `audio-filter` and `faust-dsp`/`dpf` were being handled correctly.

## Test plan
- [x] `npx prettier --check src/fetch.ts`
- [x] `npx eslint src/fetch.ts`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (7 passed)
- [x] Verified regex against faustfilters' real topic list before/after the fix