### PR TITLE
fix(fetch): trim whitespace from README image URLs split across lines

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -884,7 +884,10 @@ async function findImageUrl(org: string, repo: string, branch: string, readme: s
   // Markdown image syntax allows an optional title after the URL, e.g. `![alt](url "title")`
   // — without stripping it, the greedy `[^)]*` tail captures the title text too, corrupting
   // the URL (seen on MichaelHurst97/Noizier, whose 404'd image fetch was actually this).
-  const stripMarkdownTitle = (u: string) => u.replace(/\s+["'][^"']*["']$/, '');
+  // Markdown also tolerates the URL wrapping onto its own line, e.g. `![alt](\nurl\n)` — since
+  // `[^)]` matches newlines, the capture group picks up the surrounding whitespace too, which
+  // breaks the fetch (seen on EMATech/MidiExplorer, whose real screenshots are linked this way).
+  const stripMarkdownTitle = (u: string) => u.trim().replace(/\s+["'][^"']*["']$/, '');
   // GitHub's drag-and-drop README image uploader produces URLs with no file extension at all —
   // either the legacy `github.com/<org>/<repo>/assets/<id>/<uuid>` form or the current
   // `github.com/user-attachments/assets/<uuid>` form — since the real extension only appears


### PR DESCRIPTION
## Summary
- Markdown tolerates `![alt](\nurl\n)` — the image URL wrapped onto its own line. Since `[^)]` in the image-matching regex matches newlines, the capture group picked up the surrounding whitespace (a leading `\n`) as part of the URL, which then 404'd when fetched.
- Found via `EMATech/MidiExplorer`, whose two real screenshots are both linked this way; fetch reported "image: not found — HTTP 404" despite the images existing and being correctly referenced.

## Test plan
- [x] `npx prettier --check src/fetch.ts`
- [x] `npx eslint src/fetch.ts`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (7 passed)
- [x] Verified regex capture before/after against the real README text