### PR TITLE
fix(fetch): filter single-word "audiounit" topic from tags

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -81,7 +81,7 @@ async function checkAttestation(org: string, repo: string, sha256: string): Prom
 // Filtering known-technical topics out before slicing to 8 means more of those slots land on
 // something semantically useful, without changing the reviewer's job of double-checking tags.
 const TECHNICAL_TOPIC_RE =
-  /^(vst|vst2|vst3(-plugins?)?|vst-plugins?|clap(-plugins?)?|lv2(-plugins?)?|au|au-plugins?|aax(-plugins?)?|ladspa(-plugins?)?|dssi|dpf|juce(-.*)?|jsfx|faust(-dsp)?|standalone|audio-plugins?|audio-unit|plugin|plugins|cli|sdk|api|library|framework|cross-platform|linux|windows|macos|osx|cmake|c|cpp|c-plus-plus|rust|python|typescript|javascript|nodejs|wasm|webassembly)$/;
+  /^(vst|vst2|vst3(-plugins?)?|vst-plugins?|clap(-plugins?)?|lv2(-plugins?)?|au|au-plugins?|audiounit|aax(-plugins?)?|ladspa(-plugins?)?|dssi|dpf|juce(-.*)?|jsfx|faust(-dsp)?|standalone|audio-plugins?|audio-unit|plugin|plugins|cli|sdk|api|library|framework|cross-platform|linux|windows|macos|osx|cmake|c|cpp|c-plus-plus|rust|python|typescript|javascript|nodejs|wasm|webassembly)$/;
 
 function slugToTitleCase(slug: string): string {
   return slug


### PR DESCRIPTION
## Summary
- `TECHNICAL_TOPIC_RE` covered `au` and `audio-unit` but not the single merged word `audiounit`, a common GitHub topic spelling — it slipped through and appeared as a "Audiounit" tag.
- Found via `reillypascal/RSBrokenMedia`, whose topics include `audiounit` alongside `au`.

## Test plan
- [x] `npx prettier --check src/fetch.ts`
- [x] `npx eslint src/fetch.ts`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (7 passed)