### PR TITLE
Fix validate.ts path splitting on Windows

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -17,8 +17,10 @@ import path from 'path';
 import { ZodIssue } from 'zod';
 
 const filePath: string = process.argv[2];
-const subPath: string = filePath.split(path.sep).slice(2).join(path.sep);
-// const type: string = filePath.split(path.sep).slice(1, 2).join(path.sep);
+// Split on either separator so a forward-slash path (the form used in AGENTS.md's own
+// example command) still splits correctly when run on Windows, where path.sep is '\\'.
+const subPath: string = filePath.split(/[\\/]/).slice(2).join(path.sep);
+// const type: string = filePath.split(/[\\/]/).slice(1, 2).join(path.sep);
 const slug: string = pathGetSlug(subPath, path.sep);
 const version: string = pathGetVersion(subPath, path.sep);
 


### PR DESCRIPTION
## Summary
- `src/validate.ts` split the incoming file path with `path.sep`, so on Windows (`path.sep === '\\'`) a path written with forward slashes — including the exact form used in AGENTS.md's own example command — never split.
- `subPath` ended up empty, `slug`/`version` came back `undefined`, the report printed `✓ undefined/undefined/undefined`, and the run then crashed in `path.join` (`TypeError [ERR_INVALID_ARG_TYPE]`).
- Splitting on `/[\\/]/` instead handles both separator styles, then rejoins with the native `path.sep` before handing off to `pathGetSlug`/`pathGetVersion`.

Reported by @gPTPPs in #844.

## Test plan
- [x] `npx prettier --check src/validate.ts`
- [x] `npx eslint src/validate.ts`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (7 passed)
- [x] Simulated the Windows scenario directly (forward-slash path + `path.sep` forced to `\\`): old code produced an empty `subPath`, new code correctly resolves it
- [x] `npx tsx src/validate.ts src/plugins/crowbait/gnomedistort-2/1.0.0/index.yaml` still resolves and validates correctly on this platform (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)