### PR TITLE
[Plugin] Update LSP Plugins to 1.2.35

### DIFF
--- a/src/plugins/lsp-plugins/lsp-plugins/1.2.35/index.yaml
+++ b/src/plugins/lsp-plugins/lsp-plugins/1.2.35/index.yaml
@@ -1,0 +1,77 @@
+name: LSP Plugins
+author: Vladimir Sadovnikov
+description: A collection of open-source audio effects, synthesizers, and tools designed for music and sound production, primarily on the GNU/Linux platform.
+license: lgpl-3.0
+type: effect
+tags:
+  - Effect
+  - Multiband
+  - Dynamics
+  - Gate
+  - Density
+  - Phase
+  - De-Esser
+  - Breath Control
+url: https://github.com/lsp-plugins/lsp-plugins
+audio: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/lsp-plugins/lsp-plugins/lsp-plugins.flac
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/lsp-plugins/lsp-plugins/lsp-plugins.jpg
+donate: https://www.patreon.com/c/sadko4u
+date: '2026-08-23T13:19:32Z'
+changes: |
+  * Bugfix in JACK driver that could cause connection estimation problem on the
+    libjack library that could not be detected under PipeWire.
+  * Updated build scripts that could crash on binary dependencies when issuing
+    multithreaded build.
+files:
+  - systems:
+      - type: linux
+    architectures:
+      - arm64
+    contains:
+      - clap
+      - lv2
+      - vst3
+      - so
+    type: archive
+    size: 35839682
+    sha256: 045d15f8a2f2b9c020cada7c22ed8d62f8d65bf665c4f271626817bd68d036c3
+    url: https://github.com/lsp-plugins/lsp-plugins/releases/download/1.2.35/lsp-plugins-1.2.35-Linux-aarch64.7z
+  - systems:
+      - type: linux
+    architectures:
+      - arm32
+    contains:
+      - clap
+      - lv2
+      - vst3
+      - so
+    type: archive
+    size: 32189163
+    sha256: 4f5b0879bb0bc10b079d381f46f6b6f762247886a3889351c5c9a444343a3ed0
+    url: https://github.com/lsp-plugins/lsp-plugins/releases/download/1.2.35/lsp-plugins-1.2.35-Linux-arm32.7z
+  - systems:
+      - type: linux
+    architectures:
+      - x32
+    contains:
+      - clap
+      - lv2
+      - vst3
+      - so
+    type: archive
+    size: 32961513
+    sha256: 83903f25f1fb57948ac67a76efa835c69f7a0237648a94a1de81e3ec0ad24a61
+    url: https://github.com/lsp-plugins/lsp-plugins/releases/download/1.2.35/lsp-plugins-1.2.35-Linux-i586.7z
+  - systems:
+      - type: linux
+    architectures:
+      - x64
+    contains:
+      - clap
+      - lv2
+      - vst3
+      - so
+    type: archive
+    size: 38793460
+    sha256: 4ef3b2f63b29a522fdaf3a18f879c1c85c82f0bdd1e0b3c849a5f3c4b08d2550
+    url: https://github.com/lsp-plugins/lsp-plugins/releases/download/1.2.35/lsp-plugins-1.2.35-Linux-x86_64.7z


### PR DESCRIPTION
Updates LSP Plugins to 1.2.35.

Changes:
* Bugfix in JACK driver that could cause connection estimation problem on the libjack library that could not be detected under PipeWire.
* Updated build scripts that could crash on binary dependencies when issuing multithreaded build.

Kept the existing curated `name`/`description`/`tags`/`url`/`image`/`audio` from the 1.2.34 entry, only bumping `date`, `changes`, and `files`. Only the 4 genuine Linux archives (aarch64, arm32, i586, x86_64) are included — the release also ships FreeBSD builds and doc/src tarballs, which are excluded consistent with prior versions.

Closes #934