### PR TITLE
Update WetDelay to 1.2.0

### DIFF
--- a/src/plugins/yonie/wetdelay/1.2.0/index.yaml
+++ b/src/plugins/yonie/wetdelay/1.2.0/index.yaml
@@ -1,0 +1,27 @@
+name: Wet Delay
+author: yonie
+description: 'An open-source stereo delay with 80s rack-style character: 24 kHz internal rate, 12-bit quantisation, channel crosstalk. Free, MIT, VST3 for Windows, macOS and Linux.'
+license: mit
+type: effect
+tags:
+  - Delay
+  - Vintage
+  - Lo-Fi
+url: https://github.com/yonie/WetDelay
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/yonie/wetdelay/wetdelay.jpg
+date: '2026-08-28T19:56:19Z'
+changes: Adds a UI zoom option for high-resolution displays. Right-click the panel and choose 75, 100 or 125 percent.
+files:
+  - systems:
+      - type: mac
+      - type: win
+      - type: linux
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst3
+    type: archive
+    size: 4344927
+    sha256: 5e0e783e930963b81912bf2b7c953dc5423dbb54ec288a80d31b1d2f795a2542
+    url: https://github.com/yonie/WetDelay/releases/download/v1.2.0/WetDelay-v1.2.0.zip


### PR DESCRIPTION
Version bump for the existing `yonie/wetdelay` entry, which is currently listed at 1.1.4.

WetDelay 1.2.0 was released 2026-08-30: https://github.com/yonie/WetDelay/releases/tag/v1.2.0

The only change in this version is a UI zoom option (right-click the panel, 75/100/125 percent),
added after users reported the panel being small on high-resolution displays. No audio changes.

**For review:** `npm run dev:fetch` generated this except the `files:` block — it skipped the
release asset with *"no system/platform recognized, even after archive inspection"*, because the
single universal VST3 bundle carries all three platforms and the filename says so nowhere. The
block is copied in shape from the already-merged `wetdelay/1.1.4` entry, with size and sha256 recomputed
from the new zip.

`npm run dev:validate` passes. Tags match the existing entry.
