### PR TITLE
Update WetReverb to 1.1.0

### DIFF
--- a/src/plugins/yonie/wetreverb/1.1.0/index.yaml
+++ b/src/plugins/yonie/wetreverb/1.1.0/index.yaml
@@ -1,0 +1,27 @@
+name: Wet Reverb
+author: yonie
+description: 'An open-source reverb with 80s rack-style character: five modes, 24 kHz internal rate, 12-bit quantisation. Free, MIT, VST3 for Windows, macOS and Linux.'
+license: mit
+type: effect
+tags:
+  - Reverb
+  - Vintage
+  - Lo-Fi
+url: https://github.com/yonie/WetReverb
+image: https://open-audio-stack.github.io/open-audio-stack-registry/plugins/yonie/wetreverb/wetreverb.jpg
+date: '2026-08-28T19:56:49Z'
+changes: Adds a UI zoom option for high-resolution displays. Right-click the panel and choose 75, 100 or 125 percent.
+files:
+  - systems:
+      - type: mac
+      - type: win
+      - type: linux
+    architectures:
+      - arm64
+      - x64
+    contains:
+      - vst3
+    type: archive
+    size: 4733779
+    sha256: 5558474c171e40ba8bf847ba56dd79fee68b390f063d66a667edb5c996a80dad
+    url: https://github.com/yonie/WetReverb/releases/download/v1.1.0/WetReverb-v1.1.0.zip


### PR DESCRIPTION
Version bump for the existing `yonie/wetreverb` entry, which is currently listed at 1.0.1.

WetReverb 1.1.0 was released 2026-08-30: https://github.com/yonie/WetReverb/releases/tag/v1.1.0

The only change in this version is a UI zoom option (right-click the panel, 75/100/125 percent),
added after users reported the panel being small on high-resolution displays. No audio changes.

**For review:** `npm run dev:fetch` generated this except the `files:` block — it skipped the
release asset with *"no system/platform recognized, even after archive inspection"*, because the
single universal VST3 bundle carries all three platforms and the filename says so nowhere. The
block is copied in shape from the already-merged `wetreverb/1.0.1` entry, with size and sha256 recomputed
from the new zip.

`npm run dev:validate` passes. Tags match the existing entry.
